### PR TITLE
DOCSP-30628 Migrate Sync Jobs Drawer

### DIFF
--- a/source/code-generation/code-generation.txt
+++ b/source/code-generation/code-generation.txt
@@ -1,3 +1,5 @@
+.. _rm-code-generation:
+
 ===============
 Code Generation
 ===============

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -1,3 +1,5 @@
+.. _rm-mongodb-connection-string:
+
 ===================================
 MongoDB Database Connection Strings
 ===================================

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -1,4 +1,4 @@
-.. _rm-mongodb-connection-string:
+.. _rm-mongodb-database-connection-strings:
 
 ===================================
 MongoDB Database Connection Strings

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -1,3 +1,5 @@
+.. _rm-relational-database-connection-strings:
+
 ======================================
 Relational Database Connection Strings
 ======================================

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -120,7 +120,9 @@ Steps
    This script includes the required configuration statements 
    and additional instructions in the form of comments. 
 
-   .. warning: Before proceeding with starting a sync job
+   .. warning: 
+
+      Before proceeding with starting a sync job:
 
       1. Download the script. 
       2. Carefully review its contents.

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -25,7 +25,7 @@ Before you Begin
 
 - :ref:`Create one or more mapping rules <rm-create-mapping-rules>` in your 
   Relational Migrator project.
-- Prepare a :ref:`MongoDB URI <rm-mongodb-connection-string>` and
+- Prepare a :ref:`MongoDB URI <rm-mongodb-database-connection-strings>` and
   credentials that have read/write permissions on your destination database.
 
 Steps

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -114,7 +114,7 @@ Steps
    job type on the :guilabel:`Migration Options` form, Relational Migrator
    conducts various checks to ensure that the database is configured 
    correctly. If any configuration is missing, a banner appears indicating
-   that the database is not properly configured with a 
+   that the database is not properly configured, with a 
    :guilabel:`GENERATE SCRIPT` button to download a SQL script. 
 
    This script includes the required configuration statements 
@@ -142,7 +142,7 @@ see the follow Debezium reference links, which are internally utilized by Relati
 * `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
 * `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
 
-See :ref:`rm-data-Verification` to learn more about the data verification process.
+:ref:`rm-data-Verification`
 
 Next Steps
 ----------

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -84,9 +84,10 @@ Steps
 #. Click :guilabel:`Connect`. 
 
 #. On the :guilabel:`Connect Destination DB` form, input your 
-   :guilabel:`MongoDB connection string (URI)`. If you leave any of the form 
-   fields for :guilabel:`Database`, :guilabel:`Username`, or :guilabel:`Password` blank, 
-   the values specified in the URI are used.
+   :guilabel:`MongoDB connection string (URI)`.
+
+   If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
+   or :guilabel:`Password` blank, the values specified in the URI are used.
 
 #. Click :guilabel:`Connect`.
 
@@ -120,9 +121,7 @@ Steps
    This script includes the required configuration statements 
    and additional instructions in the form of comments. 
 
-   .. warning: 
-
-      Before proceeding with starting a sync job:
+   .. warning:: Before proceeding with starting a sync job
 
       1. Download the script. 
       2. Carefully review its contents.

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -21,7 +21,8 @@ need to be the same as the credentials used when creating your project.
 Before you Begin
 ----------------
 
-- :ref:`Create one or more mapping rules <rm-create-mapping-rules>` in your Relational Migrator project.
+- :ref:`Create one or more mapping rules <rm-create-mapping-rules>` in your 
+  Relational Migrator project.
 - Prepare a :ref:`MongoDB URI <rm-mongodb-connection-string>` and
   credentials that have read/write permissions on your destination database.
 
@@ -29,15 +30,15 @@ Steps
 -----
 
 #. On the :guilabel:`Data Migration` tab, click :guilabel:`Create Sync Job`. 
-
    Relational Migrator only runs one sync job at a time. If a sync job is in progress, this button is disabled.
 
-#. On the :guilabel:`Connect Source DB` form, enter the connection details to create the JDBC URI for your relational database. 
-
+#. On the :guilabel:`Connect Source DB` form, enter the connection details 
+   to create the JDBC URI for your relational database. 
    2a. Select a database type from the :guilabel:`Database type` drop-down. 
    2b. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
    2c. Enter a port number in the :guilabel:`Port` text box. 
-   2d. Enter a database name in the :guilabel:`Database` text field. 
+   2d. Enter a database name in the :guilabel:`Database` text field.
+
    Depending on your relational database, this behavior varies:
 
    .. list-table::
@@ -54,7 +55,7 @@ Steps
       * - Postgres 
         - Leaving database name blank loads schemas from the default database.
 
-   2e. Enter a user name in the :guilabel:`Username` text box. 
+   2e. Enter a username in the :guilabel:`Username` text box. 
    2f. Enter a password in the :guilabel:`Password` text box. 
    2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox. 
    2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode. 
@@ -67,34 +68,39 @@ Steps
       to select an :guilabel:`Identifier` for Oracle and :guilabel:`Authentication`
       for SQL Server.
 
-
-   If you want to specify the JDBC URI manually, click the :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` form. For details, see `Relational Database Connection Strings <../../Connection-Strings/relational-database-connection-strings>`__.
+   If you want to specify the JDBC URI manually, click the 
+   :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` 
+   form. For details, see 
+   :ref:`rm-relational-database-connection-strings`
 
 #. Click :guilabel:`Connect`. 
 
-#. On the :guilabel:`Connect Destination DB` form, input your :guilabel:`MongoDB connection string (URI)`. If you leave any of the form fields for :guilabel:`Database**\ , :guilabel:`Username**\ , or :guilabel:`Password` blank, the values specified in the URI are used.
+#. On the :guilabel:`Connect Destination DB` form, input your 
+   :guilabel:`MongoDB connection string (URI)`. If you leave any of the form 
+   fields for :guilabel:`Database`, :guilabel:`Username`, or :guilabel:`Password` blank, 
+   the values specified in the URI are used.
 
 #. Click :guilabel:`Connect`.
 
-#. On the :guilabel:`Migration Options` form, select your :guilabel:`Migration Options` :
+#. On the :guilabel:`Migration Options` form, select your 
+   :guilabel:`Migration Options` :
 
    .. list-table::
       :header-rows: 1
 
       * - Migration Option
         - Description
-
-   * - Mode 
-     - Defines the type of sync job.
-   * - Drop destination collections before migration  
-     - Boolean. Indicates whether Relational Migrator drops a 
-       destination collection before transferring data. 
-   * - Stop after errors 
-     - Integer. Indicates the number of errors after which Relational 
-       Migrator stops the sync job.  
-   * - Verify migrated data 
-     - Boolean. If true, the sync engine checks the migrated data 
-       against the source database. Only supported for snapshot mode.
+      * - Mode 
+        - Defines the type of sync job.
+      * - Drop destination collections before migration
+        - Boolean. Indicates whether Relational Migrator drops a 
+          destination collection before transferring data. 
+      * - Stop after errors 
+        - Integer. Indicates the number of errors after which Relational 
+          Migrator stops the sync job.  
+      * - Verify migrated data 
+        - Boolean. If true, the sync engine checks the migrated data 
+          against the source database. Only supported for snapshot mode.
 
    Once you have established the database connection and specified the 
    job type on the :guilabel:`Migration Options` form, Relational Migrator
@@ -104,14 +110,14 @@ Steps
    :guilabel:`GENERATE SCRIPT` button to download a SQL script. 
 
    This script includes the required configuration statements 
-   and additional  instructions in the form of comments. 
+   and additional instructions in the form of comments. 
 
    .. warning: Before proceeding with starting a sync job
 
-      #. Download the script. 
-      #. Carefully review its contents.
-      #. Execute the statements.
-      #. Follow any commented manual steps.
+      1. Download the script. 
+      2. Carefully review its contents.
+      3. Execute the statements.
+      4. Follow any commented manual steps.
 
 #. Click :guilabel:`Start`.
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -37,13 +37,13 @@ Steps
 #. On the :guilabel:`Connect Source DB` form, enter the connection details 
    to create the JDBC URI for your relational database. 
 
-   #. Select a database type from the :guilabel:`Database type` drop-down.
+   2a. Select a database type from the :guilabel:`Database type` drop-down.
 
-   #. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
+   2b. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
 
-   #. Enter a port number in the :guilabel:`Port` text box. 
+   2c. Enter a port number in the :guilabel:`Port` text box. 
 
-   #. Enter a database name in the :guilabel:`Database` text field.
+   2d. Enter a database name in the :guilabel:`Database` text field.
 
    Depending on your relational database, this behavior varies:
 
@@ -61,15 +61,15 @@ Steps
       * - Postgres 
         - Leaving database name blank loads schemas from the default database.
 
-   #. Enter a username in the :guilabel:`Username` text box. 
+   2e. Enter a username in the :guilabel:`Username` text box. 
 
-   #. Enter a password in the :guilabel:`Password` text box. 
+   2f. Enter a password in the :guilabel:`Password` text box. 
 
-   #. (Optional) Click the :guilabel:`Save a password for this session` checkbox.
+   2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox.
 
-   #. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode.
+   2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode.
 
-   #. Click :guilabel:`Connect`.
+   2i. Click :guilabel:`Connect`.
 
    .. note::
 
@@ -94,7 +94,7 @@ Steps
 #. Click :guilabel:`Connect`.
 
 #. On the :guilabel:`Migration Options` form, select your 
-   :guilabel:`Migration Options` :
+   :guilabel:`Migration Options`:
 
    .. list-table::
       :header-rows: 1
@@ -134,6 +134,12 @@ Steps
 
 #. Click :guilabel:`Start`.
 
+Next Steps
+----------
+
+- :ref:`rm-monitor-jobs`
+- :ref:`rm-data-Verification`
+
 Learn More
 ----------
 
@@ -144,9 +150,3 @@ see the follow Debezium reference links, which are internally utilized by Relati
 * `Oracle <https://debezium.io/documentation/reference/stable/connectors/oracle.html#_preparing_the_database>`__
 * `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
 * `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
-
-Next Steps
-----------
-
-- :ref:`rm-monitor-jobs`
-- :ref:`rm-data-Verification`

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -51,7 +51,7 @@ Steps
       * - Database Type
         - Behavior
       * - Oracle 
-        - You must enter a database name and a :guilabel:`Service ID` or :guilabel:`SID`. |
+        - You must enter a database name and a :guilabel:`Service ID` or :guilabel:`SID`.
       * - SQL Server
         - Enter a database name, or leave blank to load all databases.
       * - MySQL 
@@ -78,7 +78,7 @@ Steps
 
    If you want to specify the JDBC URI manually, click the 
    :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` 
-   form. For details, see :ref:`rm-relational-database-connection-strings` .
+   form. For details, see :ref:`rm-relational-database-connection-strings`.
 
 #. Click :guilabel:`Connect`. 
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -73,7 +73,7 @@ Steps
 
       Connection and SSL details depend on the database type you are connecting to. 
       In addition to the generic connection properties listed above, you may also need
-      to select an :guilabel:`Identifier` for Oracle and :guilabel:`Authentication`
+      to select a :guilabel:`Identifier` for Oracle and :guilabel:`Authentication`
       for SQL Server.
 
    If you want to specify the JDBC URI manually, click the 
@@ -142,9 +142,8 @@ see the follow Debezium reference links, which are internally utilized by Relati
 * `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
 * `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
 
-:ref:`rm-data-Verification`
-
 Next Steps
 ----------
 
 - :ref:`rm-monitor-jobs`
+- :ref:`rm-data-Verification`

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -121,7 +121,9 @@ Steps
    This script includes the required configuration statements 
    and additional instructions in the form of comments. 
 
-   .. warning:: Before proceeding with starting a sync job
+   .. warning:: 
+
+      Before proceeding with starting a sync job:
 
       1. Download the script. 
       2. Carefully review its contents.

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -10,9 +10,11 @@ Create a Sync Job
    :depth: 1
    :class: singlecol
 
-Create new sync jobs from the :guilabel:`Data Migration` tab.
+Sync jobs are the worker processes responsible for transferring your 
+data and schemas from a relational database to MongoDB. Create a new 
+sync job from the :guilabel:`Data Migration` tab.
 
-About This Task
+About this Task
 ---------------
 
 The URI credentials you provide when creating a sync job do not 
@@ -35,13 +37,13 @@ Steps
 #. On the :guilabel:`Connect Source DB` form, enter the connection details 
    to create the JDBC URI for your relational database. 
 
-   2a. Select a database type from the :guilabel:`Database type` drop-down.
+   #. Select a database type from the :guilabel:`Database type` drop-down.
 
-   2b. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
+   #. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
 
-   2c. Enter a port number in the :guilabel:`Port` text box. 
+   #. Enter a port number in the :guilabel:`Port` text box. 
 
-   2d. Enter a database name in the :guilabel:`Database` text field.
+   #. Enter a database name in the :guilabel:`Database` text field.
 
    Depending on your relational database, this behavior varies:
 
@@ -59,15 +61,15 @@ Steps
       * - Postgres 
         - Leaving database name blank loads schemas from the default database.
 
-   2e. Enter a username in the :guilabel:`Username` text box. 
+   #. Enter a username in the :guilabel:`Username` text box. 
 
-   2f. Enter a password in the :guilabel:`Password` text box. 
+   #. Enter a password in the :guilabel:`Password` text box. 
 
-   2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox.
+   #. (Optional) Click the :guilabel:`Save a password for this session` checkbox.
 
-   2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode.
+   #. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode.
 
-   2i. Click :guilabel:`Connect`.
+   #. Click :guilabel:`Connect`.
 
    .. note::
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -78,7 +78,8 @@ Steps
 
    If you want to specify the JDBC URI manually, click the 
    :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` 
-   form. For details, see :ref:`rm-relational-database-connection-strings`.
+   form. For details, see :ref:`rm-relational-database-connection-strings`
+   .
 
 #. Click :guilabel:`Connect`. 
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -34,9 +34,13 @@ Steps
 
 #. On the :guilabel:`Connect Source DB` form, enter the connection details 
    to create the JDBC URI for your relational database. 
-   2a. Select a database type from the :guilabel:`Database type` drop-down. 
+
+   2a. Select a database type from the :guilabel:`Database type` drop-down.
+
    2b. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
+
    2c. Enter a port number in the :guilabel:`Port` text box. 
+
    2d. Enter a database name in the :guilabel:`Database` text field.
 
    Depending on your relational database, this behavior varies:
@@ -56,9 +60,13 @@ Steps
         - Leaving database name blank loads schemas from the default database.
 
    2e. Enter a username in the :guilabel:`Username` text box. 
+
    2f. Enter a password in the :guilabel:`Password` text box. 
-   2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox. 
-   2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode. 
+
+   2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox.
+
+   2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode.
+
    2i. Click :guilabel:`Connect`.
 
    .. note::

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -3,3 +3,132 @@
 =================
 Create a Sync Job
 =================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Create new sync jobs from the :guilabel:`Data Migration` tab.
+
+About This Task
+---------------
+
+The URI credentials you provide when creating a sync job do not 
+need to be the same as the credentials used when creating your project.
+
+Before you Begin
+----------------
+
+- :ref:`Create one or more mapping rules <rm-create-mapping-rules>` in your Relational Migrator project.
+- Prepare a :ref:`MongoDB URI <rm-mongodb-connection-string>` and
+  credentials that have read/write permissions on your destination database.
+
+Steps
+-----
+
+#. On the :guilabel:`Data Migration` tab, click :guilabel:`Create Sync Job`. 
+
+   Relational Migrator only runs one sync job at a time. If a sync job is in progress, this button is disabled.
+
+#. On the :guilabel:`Connect Source DB` form, enter the connection details to create the JDBC URI for your relational database. 
+
+   2a. Select a database type from the :guilabel:`Database type` drop-down. 
+   2b. Enter a host IP or DNS name in the :guilabel:`Host` text box. 
+   2c. Enter a port number in the :guilabel:`Port` text box. 
+   2d. Enter a database name in the :guilabel:`Database` text field. 
+   Depending on your relational database, this behavior varies:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Database Type
+        - Behavior
+      * - Oracle 
+        - You must enter a database name and a :guilabel:`Service ID` or :guilabel:`SID`. |
+      * - SQL Server
+        - Enter a database name, or leave blank to load all databases.
+      * - MySQL 
+        - Enter a database name, or leave blank to load all databases.
+      * - Postgres 
+        - Leaving database name blank loads schemas from the default database.
+
+   2e. Enter a user name in the :guilabel:`Username` text box. 
+   2f. Enter a password in the :guilabel:`Password` text box. 
+   2g. (Optional) Click the :guilabel:`Save a password for this session` checkbox. 
+   2h. Click the :guilabel:`SSL` toggle switch to enable or disable SSL and select an SSL mode. 
+   2i. Click :guilabel:`Connect`.
+
+   .. note::
+
+      Connection and SSL details depend on the database type you are connecting to. 
+      In addition to the generic connection properties listed above, you may also need
+      to select an :guilabel:`Identifier` for Oracle and :guilabel:`Authentication`
+      for SQL Server.
+
+
+   If you want to specify the JDBC URI manually, click the :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` form. For details, see `Relational Database Connection Strings <../../Connection-Strings/relational-database-connection-strings>`__.
+
+#. Click :guilabel:`Connect`. 
+
+#. On the :guilabel:`Connect Destination DB` form, input your :guilabel:`MongoDB connection string (URI)`. If you leave any of the form fields for :guilabel:`Database**\ , :guilabel:`Username**\ , or :guilabel:`Password` blank, the values specified in the URI are used.
+
+#. Click :guilabel:`Connect`.
+
+#. On the :guilabel:`Migration Options` form, select your :guilabel:`Migration Options` :
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Migration Option
+        - Description
+
+   * - Mode 
+     - Defines the type of sync job.
+   * - Drop destination collections before migration  
+     - Boolean. Indicates whether Relational Migrator drops a 
+       destination collection before transferring data. 
+   * - Stop after errors 
+     - Integer. Indicates the number of errors after which Relational 
+       Migrator stops the sync job.  
+   * - Verify migrated data 
+     - Boolean. If true, the sync engine checks the migrated data 
+       against the source database. Only supported for snapshot mode.
+
+   Once you have established the database connection and specified the 
+   job type on the :guilabel:`Migration Options` form, Relational Migrator
+   conducts various checks to ensure that the database is configured 
+   correctly. If any configuration is missing, a banner appears indicating
+   that the database is not properly configured with a 
+   :guilabel:`GENERATE SCRIPT` button to download a SQL script. 
+
+   This script includes the required configuration statements 
+   and additional  instructions in the form of comments. 
+
+   .. warning: Before proceeding with starting a sync job
+
+      #. Download the script. 
+      #. Carefully review its contents.
+      #. Execute the statements.
+      #. Follow any commented manual steps.
+
+#. Click :guilabel:`Start`.
+
+Learn More
+----------
+
+For detailed information regarding the configuration requirements for each database, 
+see the follow Debezium reference links, which are internally utilized by Relational Migrator:
+
+* `MySQL <https://debezium.io/documentation/reference/stable/connectors/mysql.html#setting-up-mysql>`__
+* `Oracle <https://debezium.io/documentation/reference/stable/connectors/oracle.html#_preparing_the_database>`__
+* `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
+* `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
+
+See :ref:`rm-data-Verification` to learn more about the data verification process.
+
+Next Steps
+----------
+
+:ref:`rm-monitor-jobs`

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -147,4 +147,4 @@ see the follow Debezium reference links, which are internally utilized by Relati
 Next Steps
 ----------
 
-:ref:`rm-monitor-jobs`
+- :ref:`rm-monitor-jobs`

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -78,8 +78,7 @@ Steps
 
    If you want to specify the JDBC URI manually, click the 
    :guilabel:`Enter URI manually` toggle switch on the :guilabel:`Connect SourceDB` 
-   form. For details, see 
-   :ref:`rm-relational-database-connection-strings`
+   form. For details, see :ref:`rm-relational-database-connection-strings` .
 
 #. Click :guilabel:`Connect`. 
 

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -1,3 +1,147 @@
+.. _rm-monitor-jobs:
+
 ==================
 Monitor a Sync Job
 ==================
+
+You can monitor a sync job from the :guilabel:`History` pane on the 
+:guilabel:`Data Migration` tab. The :guilabel:`History` pane contains 
+in progress, completed, and failed jobs.
+
+About this Task
+---------------
+
+Sync jobs execute in a number of distinct stages which are visible on the :guilabel:`Job overview` pane. 
+
+For example:
+
+- A snapshot sync job includes a snapshot stage and, optionally, a verification stage.
+- A continuous sync job includes a snapshot stage followed by a CDC stage. 
+
+Job Overview
+~~~~~~~~~~~~
+
+High-level sync job information displays in the top section of the :guilabel:`Job overview` pane.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Metric
+     - Description
+
+   * - Source URI  
+     - The JDBC connection string used to connect to the source relational database.
+
+   * - Destination URI   
+     - The MongoDB connection string used to connect to the destination MongoDB database.
+
+   * - Job Mode   
+     - Indicates if the sync job is snapshot or continuous. 
+
+   * - Status   
+     -  Indicates the current or end status of the sync job.   
+
+Snapshot Stage
+~~~~~~~~~~~~~~
+
+Snapshot stage information displays in the :guilabel:`Snapshot stage` section of the :guilabel:`Job overview` pane.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Metric
+     - Description
+
+   * - Snapshot stage status 
+     - Indicates the status of the snapshot stage. 
+
+   * - Started  
+     - Date and time that the snapshot stage started. 
+
+   * - Duration  
+     - Time taken for the snapshot stage to complete. 
+
+   * - Tables migrated 
+     - Total number of tables migrated from the source database. 
+
+   * - Rows migrated 
+     - Total number of rows migrated from all tables.
+
+CDC Stage
+~~~~~~~~~
+
+The CDC stage information is displayed in the :guilabel:`CDC stage` section of the :guilabel:`Job overview` pane. The CDC stage begins after the initial snapshot stage has completed and remains in the :guilabel:`RUNNING` status until it is explicitly completed or the sync job encounters an unrecoverable error.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Metric
+     - Description
+
+   * - CDC stage status 
+     - Indicates the status of the CDC stage. When a CDC stage is actively replicating 
+       data changes, this status is :guilabel:`RUNNING`.
+
+   * - Started 
+     - Date and time that Relational Migrator started listening for data change events.
+
+   * - Last event time 
+     - Latest date and time that Relational Migrator detected a data change event.
+
+   * - Total events seen 
+     - Number of data change events Relational Migrator has detected since the CDC stage started. |
+
+   * - Events in the last hour 
+     - Number of data change events Relational Migrator has detected in the last hour.
+
+Issues
+~~~~~~
+
+If your sync job has errors during execution, you can find the details in the :guilabel:`Issues` pane on the :guilabel:`Data Migration` screen.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Metric
+     - Description
+
+   * - Date & Time 
+     - The date and time that the issue occurred.
+
+   * - Table / Collection
+     - The table or collection that caused the error. This is blank if the error is global.
+
+   * - Count 
+     - Total number of errors encountered.
+
+   * - Error detail 
+     - Detailed error message from the target deployment.
+
+Steps
+-----
+
+1. Click on a previous sync job in the :guilabel:`History` pane to load the :guilabel:`Overview` and :guilabel:`Issue` information.
+
+   :guilabel:`Snapshot stage` and :guilabel:`CDC stage` logging information display next to each respective section of the :guilabel:`Job overview` pane.
+
+   ![View Job](/img/jobs/jobs-monitoring-job-history.png)
+
+2. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
+
+3. Review the debugging information in the :guilabel:`Error detail` column.
+
+Learn More
+----------
+
+- :ref:`rm-stop-jobs`
+- :ref:`rm-data-Verification`
+
+Next Steps
+----------
+
+- :ref:`rm-code-generation`
+- :ref:`rm-add-calculated-fields`

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -11,7 +11,8 @@ in progress, completed, and failed jobs.
 About this Task
 ---------------
 
-Sync jobs execute in a number of distinct stages which are visible on the :guilabel:`Job overview` pane. 
+Sync jobs execute in a number of distinct stages which are visible on 
+the :guilabel:`Job overview` pane. 
 
 For example:
 
@@ -72,7 +73,10 @@ Snapshot stage information displays in the :guilabel:`Snapshot stage` section of
 CDC Stage
 ~~~~~~~~~
 
-The CDC stage information is displayed in the :guilabel:`CDC stage` section of the :guilabel:`Job overview` pane. The CDC stage begins after the initial snapshot stage has completed and remains in the :guilabel:`RUNNING` status until it is explicitly completed or the sync job encounters an unrecoverable error.
+The CDC stage information is displayed in the :guilabel:`CDC stage` section 
+of the :guilabel:`Job overview` pane. The CDC stage begins after the initial 
+snapshot stage has completed and remains in the :guilabel:`RUNNING` status 
+until it is explicitly completed or the sync job encounters an unrecoverable error.
 
 .. list-table::
    :header-rows: 1
@@ -100,7 +104,8 @@ The CDC stage information is displayed in the :guilabel:`CDC stage` section of t
 Issues
 ~~~~~~
 
-If your sync job has errors during execution, you can find the details in the :guilabel:`Issues` pane on the :guilabel:`Data Migration` screen.
+If your sync job has errors during execution, you can find the details 
+in the :guilabel:`Issues` pane on the :guilabel:`Data Migration` screen.
 
 .. list-table::
    :header-rows: 1

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -124,15 +124,16 @@ If your sync job has errors during execution, you can find the details in the :g
 Steps
 -----
 
-1. Click on a previous sync job in the :guilabel:`History` pane to load the :guilabel:`Overview` and :guilabel:`Issue` information.
+#. Click on a previous sync job in the :guilabel:`History` pane to load the :guilabel:`Overview` and :guilabel:`Issue` information.
 
    :guilabel:`Snapshot stage` and :guilabel:`CDC stage` logging information display next to each respective section of the :guilabel:`Job overview` pane.
 
-   ![View Job](/img/jobs/jobs-monitoring-job-history.png)
+   .. image:: /img/jobs/jobs-monitoring-job-history.png
+      :alt: View Job History
 
-2. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
+#. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
 
-3. Review the debugging information in the :guilabel:`Error detail` column.
+#. Review the debugging information in the :guilabel:`Error detail` column.
 
 Learn More
 ----------

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -4,6 +4,12 @@
 Monitor a Sync Job
 ==================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 You can monitor a sync job from the :guilabel:`History` pane on the 
 :guilabel:`Data Migration` tab. The :guilabel:`History` pane contains 
 in progress, completed, and failed jobs.

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -102,7 +102,7 @@ until it is explicitly completed or the sync job encounters an unrecoverable err
      - Latest date and time that Relational Migrator detected a data change event.
 
    * - Total events seen 
-     - Number of data change events Relational Migrator has detected since the CDC stage started. |
+     - Number of data change events Relational Migrator has detected since the CDC stage started.
 
    * - Events in the last hour 
      - Number of data change events Relational Migrator has detected in the last hour.

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -135,7 +135,7 @@ in the :guilabel:`Issues` pane on the :guilabel:`Data Migration` screen.
 Steps
 -----
 
-#. Click on a previous sync job in the :guilabel:`History` pane to load the :guilabel:`Overview` and :guilabel:`Issue` information.
+1. Click on a previous sync job in the :guilabel:`History` pane to load the :guilabel:`Overview` and :guilabel:`Issue` information.
 
    :guilabel:`Snapshot stage` and :guilabel:`CDC stage` logging information display next to each respective section of the :guilabel:`Job overview` pane.
 
@@ -144,9 +144,9 @@ Steps
 
 |
 
-#. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
+2. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
 
-#. Review the debugging information in the :guilabel:`Error detail` column.
+3. Review the debugging information in the :guilabel:`Error detail` column.
 
 Learn More
 ----------

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -142,6 +142,7 @@ Steps
    .. image:: /img/jobs/jobs-monitoring-job-history.png
       :alt: View Job History
 
+|
 
 #. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
 

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -142,6 +142,7 @@ Steps
    .. image:: /img/jobs/jobs-monitoring-job-history.png
       :alt: View Job History
 
+
 #. Click the :guilabel:`>` icon under the :guilabel:`Issues` section to view sync job errors.
 
 #. Review the debugging information in the :guilabel:`Error detail` column.

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -17,7 +17,7 @@ in progress, completed, and failed jobs.
 About this Task
 ---------------
 
-Sync jobs execute in a number of distinct stages which are visible on 
+Sync jobs execute in a number of distinct stages, which are visible on 
 the :guilabel:`Job overview` pane. 
 
 For example:
@@ -82,7 +82,7 @@ CDC Stage
 The CDC stage information is displayed in the :guilabel:`CDC stage` section 
 of the :guilabel:`Job overview` pane. The CDC stage begins after the initial 
 snapshot stage has completed and remains in the :guilabel:`RUNNING` status 
-until it is explicitly completed or the sync job encounters an unrecoverable error.
+until it is explicitly completed, or the sync job encounters an unrecoverable error.
 
 .. list-table::
    :header-rows: 1

--- a/source/jobs/monitoring-jobs.txt
+++ b/source/jobs/monitoring-jobs.txt
@@ -12,7 +12,7 @@ Monitor a Sync Job
 
 You can monitor a sync job from the :guilabel:`History` pane on the 
 :guilabel:`Data Migration` tab. The :guilabel:`History` pane contains 
-in progress, completed, and failed jobs.
+information about in progress, completed, and failed sync jobs.
 
 About this Task
 ---------------
@@ -23,7 +23,7 @@ the :guilabel:`Job overview` pane.
 For example:
 
 - A snapshot sync job includes a snapshot stage and, optionally, a verification stage.
-- A continuous sync job includes a snapshot stage followed by a CDC stage. 
+- A continuous sync job includes a snapshot stage, followed by a CDC stage. 
 
 Job Overview
 ~~~~~~~~~~~~
@@ -148,14 +148,14 @@ Steps
 
 3. Review the debugging information in the :guilabel:`Error detail` column.
 
-Learn More
-----------
-
-- :ref:`rm-stop-jobs`
-- :ref:`rm-data-Verification`
-
 Next Steps
 ----------
 
 - :ref:`rm-code-generation`
 - :ref:`rm-add-calculated-fields`
+
+Learn More
+----------
+
+- :ref:`rm-stop-jobs`
+- :ref:`rm-data-Verification`

--- a/source/jobs/stopping-jobs.txt
+++ b/source/jobs/stopping-jobs.txt
@@ -4,4 +4,60 @@
 Stop a Sync Job
 ===============
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+You can stop a sync job from the **Job Overview** pane on the **Data Migration** tab.
+
+About this Task
+---------------
+
+The effects of stopping a sync job on your destination database depend on 
+the type and stage of the sync job:
+
+- If you stop a snapshot sync job during the snapshot stage, any 
+  partially migrated data remains in the MongoDB database.
+- If you stop a continuous sync job during the CDC stage, the process 
+  ends gracefully, and Relational Migrator cleans up any temporary data.
+
+Once initiated, the process of canceling or completing a sync job may take up to one minute.
+
+Steps
+-----
+
+To stop your sync job, follow the instructions below based on the current stage of execution:
+
+.. tabs::
+
+      tabs:
+
+         - id: stop-snapshot
+           name: Stop a Sync Job in Snapshot stage
+           content: |
+
+              #. Open the :guilabel:`Data Migration` tab.
+              #. Click on the sync job in the :guilabel:`History` pane.
+              #. Click the red :guilabel:`Terminate` button in the upper-right corner of the screen.
+              #. Click the red :guilabel:`Terminate` button on the pop-up modal.
+                 Once a sync job cancels, an :guilabel:`x` icon displays 
+                 in the :guilabel:`History` pane, and the status of the sync
+                 job updates to :guilabel:`Snapshot cancelled`.
+
+         - id: stop-cdc
+           name: Stop a Sync Job in CDC stage
+           content: |
+              #. Open the :guilabel:`Data Migration` tab.
+              #. Click on the sync job in the :guilabel:`History` pane.
+              #. Click the red :guilabel:`Terminate` button in the upper-right corner of the screen.
+              #. Click the red :guilabel:`Terminate` button on the pop-up modal.
+                 Once a sync job cancels, an :guilabel:`x` icon displays in the  :guilabel:`History` pane, and the status of the sync job updates to :guilabel:`Snapshot cancelled`.
+
+Learn More
+----------
+
+:ref:`rm-create-jobs`
+:ref:`rm-monitor-jobs`
 

--- a/source/jobs/stopping-jobs.txt
+++ b/source/jobs/stopping-jobs.txt
@@ -1,3 +1,5 @@
+.. _rm-stop-jobs:
+
 ===============
 Stop a Sync Job
 ===============

--- a/source/jobs/stopping-jobs.txt
+++ b/source/jobs/stopping-jobs.txt
@@ -10,7 +10,8 @@ Stop a Sync Job
    :depth: 1
    :class: singlecol
 
-You can stop a sync job from the **Job Overview** pane on the **Data Migration** tab.
+You can stop a sync job from the :guilabel:`Job Overview` pane on the 
+:guilabel:`Data Migration` tab.
 
 About this Task
 ---------------

--- a/source/jobs/stopping-jobs.txt
+++ b/source/jobs/stopping-jobs.txt
@@ -59,6 +59,6 @@ To stop your sync job, follow the instructions below based on the current stage 
 Learn More
 ----------
 
-:ref:`rm-create-jobs`
-:ref:`rm-monitor-jobs`
+- :ref:`rm-create-jobs`
+- :ref:`rm-monitor-jobs`
 

--- a/source/jobs/stopping-jobs.txt
+++ b/source/jobs/stopping-jobs.txt
@@ -51,9 +51,9 @@ To stop your sync job, follow the instructions below based on the current stage 
            content: |
               #. Open the :guilabel:`Data Migration` tab.
               #. Click on the sync job in the :guilabel:`History` pane.
-              #. Click the red :guilabel:`Terminate` button in the upper-right corner of the screen.
-              #. Click the red :guilabel:`Terminate` button on the pop-up modal.
-                 Once a sync job cancels, an :guilabel:`x` icon displays in the  :guilabel:`History` pane, and the status of the sync job updates to :guilabel:`Snapshot cancelled`.
+              #. Click the :guilabel:`Complete CDC`  button in the upper-right corner of the screen.
+              #. Click the green :guilabel:`Complete CDC` button on the pop-up modal.
+                 Once the sync job completes, a checkmark icon displays in the :guilabel:`History` pane, all stages display a status of :guilabel:`COMPLETED`, and the status of the sync job updates to :guilabel:`CDC completed`.
 
 Learn More
 ----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -4,6 +4,42 @@
 Sync Jobs
 =========
 
+Sync jobs transfer data from your relational database to MongoDB. Sync 
+jobs use project-level :ref:`rm-mapping-rules` to distribute data to 
+your MongoDB database.
+
+Types of Sync Jobs
+------------------
+
+Relational Migrator offers two different sync job types:
+
+**Snapshot**: Snapshot sync jobs run once, typically for a point in time migration strategy.
+**Continuous**: Continuous sync jobs cover new incoming data for a zero-downtime Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first, followed by a CDC stage that captures database updates in near-real time. When you run a continuous sync job, your source and destination database data remain in sync.
+
+.. note:: Private Preview : Kafka Deployment Model
+
+   The Kafka deployment model of Relational Migrator allows you to run 
+   longer-running snapshot or continuous sync jobs with improved resiliency. 
+   This model is currently available in private preview. If you are interested
+   in learning about or testing this model, please contact your MongoDB account team.
+
+Get Started
+-----------
+
+You can perform the following tasks from the **Data Migration** tab.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Task
+     - Description
+   * - :ref:`rm-create-jobs`
+     - Create a sync job which uses the defined mapping rules and migration options.
+   * - :ref:`rm-monitor-jobs`
+     - View meta data, execution status, and issues for a sync job.
+   * - :ref:`rm-stop-jobs`
+     - Cancels the execution of a sync job.
+
 .. toctree::
    :titlesonly:
    :hidden:

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -1,3 +1,5 @@
+.. _rm-sync-jobs:
+
 =========
 Sync Jobs
 =========

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -13,8 +13,14 @@ Types of Sync Jobs
 
 Relational Migrator offers two different sync job types:
 
-**Snapshot**: Snapshot sync jobs run once, typically for a point in time migration strategy.
-**Continuous**: Continuous sync jobs cover new incoming data for a zero-downtime Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first, followed by a CDC stage that captures database updates in near-real time. When you run a continuous sync job, your source and destination database data remain in sync.
+**Snapshot**: Snapshot sync jobs run once, typically for a point in time 
+migration strategy.
+
+**Continuous**: Continuous sync jobs cover new incoming data for a zero-downtime 
+Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
+followed by a CDC stage that captures database updates in near-real time. 
+When you run a continuous sync job, your source and destination database 
+data remain in sync.
 
 .. note:: Private Preview : Kafka Deployment Model
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -42,7 +42,7 @@ You can perform the following tasks from the **Data Migration** tab.
    * - :ref:`rm-create-jobs`
      - Create a sync job which uses the defined mapping rules and migration options.
    * - :ref:`rm-monitor-jobs`
-     - View meta data, execution status, and issues for a sync job.
+     - View metadata, execution status, and issues for a sync job.
    * - :ref:`rm-stop-jobs`
      - Cancels the execution of a sync job.
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -1,3 +1,5 @@
+.. _rm-add-calculated-fields:
+
 =====================
 Add Calculated Fields
 =====================


### PR DESCRIPTION
## Description

Sync Job drawer conversion from markdown to snooty.

## Staging

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30628/jobs/sync-jobs/

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30628/jobs/creating-jobs/

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30628/jobs/monitoring-jobs/

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30628/jobs/stopping-jobs/

## Jira

https://jira.mongodb.org/browse/DOCSP-30628


## Build

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64886cb367a273b816d5ff9b