### PR TITLE
DOCSP-30630 Navigate Diagrams and Entities Drawer

### DIFF
--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -24,7 +24,7 @@ automatically adjusted to display your chosen layout.
 Steps
 -----
 
-#. Click the tree diagram icon at the top of the diagram view.
+#. Click the tree diagram icon at the top-left of the :guilabel:`diagram` view.
 
 #. Choose your layout.
 

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -30,8 +30,8 @@ To apply a layout to a diagram:
 Layout Options
 --------------
 
-Relational Migrator provides three layout options.
-The following tabs show examples of each layout option.
+Relational Migrator offers three layout options. 
+The examples of each layout option are shown in the following tabs:
 
 .. tabs::
 

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -1,3 +1,5 @@
+.. _rm-apply-layout:
+
 ===========================
 Apply a Layout to a Diagram
 ===========================

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -36,7 +36,7 @@ Relational Migrator provides three layout options:
 - Top to Bottom
 - Star
 
-The following sections show examples of each layout option.
+The following tabs show examples of each layout option.
 
 .. tabs::
 

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -30,12 +30,7 @@ To apply a layout to a diagram:
 Layout Options
 --------------
 
-Relational Migrator provides three layout options:
-
-- Left to Right
-- Top to Bottom
-- Star
-
+Relational Migrator provides three layout options.
 The following tabs show examples of each layout option.
 
 .. tabs::

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -24,8 +24,6 @@ automatically adjusted to display your chosen layout.
 Steps
 -----
 
-To apply a layout to a diagram:
-
 #. Click the tree diagram icon at the top of the diagram view.
 
 #. Choose your layout.

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -57,22 +57,3 @@ The following tabs show examples of each layout option.
 
       .. image:: /img/diagrams/layouts/star.png
          :alt: Star Layout
-
-
-Left to Right
-~~~~~~~~~~~~~
-
-.. image:: /img/diagrams/layouts/left-to-right.png
-   :alt: Left to Right Layout
-
-Top to Bottom
-~~~~~~~~~~~~~
-
-.. image:: /img/diagrams/layouts/top-to-bottom.png
-   :alt: Top to Bottom Layout
-
-Star
-~~~~
-
-.. image:: /img/diagrams/layouts/star.png
-   :alt: Star Layout

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -34,7 +34,7 @@ Layout Options
 --------------
 
 Relational Migrator offers three layout options. 
-The examples of each layout option are shown in the following tabs:
+Examples of each layout option are shown in the following tabs:
 
 .. tabs::
 

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -3,3 +3,49 @@
 ===========================
 Apply a Layout to a Diagram
 ===========================
+
+You can apply a preset layout to your diagram to organize its entities.
+Use diagram layouts to neatly arrange entities without needing to
+manually click and drag them.
+
+When you apply a layout to a diagram, Relational Migrator applies the
+layout to both the Relational and MongoDB views. The zoom level is
+automatically adjusted to display your chosen layout.
+
+Steps
+-----
+
+To apply a layout to a diagram:
+
+#. Click the tree diagram icon at the top of the diagram view.
+
+#. Choose your layout.
+
+Layout Options
+--------------
+
+Relational Migrator provides three layout options:
+
+- Left to Right
+- Top to Bottom
+- Star
+
+The following sections show examples of each layout option.
+
+Left to Right
+~~~~~~~~~~~~~
+
+.. image:: /img/diagrams/layouts/left-to-right.png
+   :alt: Left to Right Layout
+
+Top to Bottom
+~~~~~~~~~~~~~
+
+.. image:: /img/diagrams/layouts/top-to-bottom.png
+   :alt: Top to Bottom Layout
+
+Star
+~~~~
+
+.. image:: /img/diagrams/layouts/star.png
+   :alt: Star Layout

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -14,6 +14,9 @@ You can apply a preset layout to your diagram to organize its entities.
 Use diagram layouts to neatly arrange entities without needing to
 manually click and drag them.
 
+About this Task
+---------------
+
 When you apply a layout to a diagram, Relational Migrator applies the
 layout to both the Relational and MongoDB views. The zoom level is
 automatically adjusted to display your chosen layout.

--- a/source/diagrams/navigate-diagrams/apply-layout.txt
+++ b/source/diagrams/navigate-diagrams/apply-layout.txt
@@ -4,6 +4,12 @@
 Apply a Layout to a Diagram
 ===========================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 You can apply a preset layout to your diagram to organize its entities.
 Use diagram layouts to neatly arrange entities without needing to
 manually click and drag them.
@@ -31,6 +37,27 @@ Relational Migrator provides three layout options:
 - Star
 
 The following sections show examples of each layout option.
+
+.. tabs::
+
+   .. tab:: Left to Right Layout
+      :tabid: left-to-right
+
+      .. image:: /img/diagrams/layouts/left-to-right.png
+         :alt: Left to Right Layout
+
+   .. tab:: Top to Bottom Layout
+      :tabid: top-to-bottom
+
+      .. image:: /img/diagrams/layouts/top-to-bottom.png
+         :alt: Top to Bottom Layout
+
+   .. tab:: Star Layout
+      :tabid: star
+
+      .. image:: /img/diagrams/layouts/star.png
+         :alt: Star Layout
+
 
 Left to Right
 ~~~~~~~~~~~~~

--- a/source/diagrams/navigate-diagrams/navigate-diagrams.txt
+++ b/source/diagrams/navigate-diagrams/navigate-diagrams.txt
@@ -67,7 +67,7 @@ returns to Pan Mode.
 Learn More
 ----------
 
-To organize diagram entities, see :ref:`rm-apply-layout`
+:ref:`rm-apply-layout`
 
 .. toctree::
    :hidden:

--- a/source/diagrams/navigate-diagrams/navigate-diagrams.txt
+++ b/source/diagrams/navigate-diagrams/navigate-diagrams.txt
@@ -5,7 +5,7 @@ Navigate Diagrams and Entities
 This page describes how to navigate your project's diagrams and
 entities.
 
-After you :ref:`rm-create-project-live`, Relational
+After you :ref:`Create a Project<rm-create-project-live>`, Relational
 Migrator creates an initial diagram containing the entities and
 relationships in the Relational and MongoDB models.
 

--- a/source/diagrams/navigate-diagrams/navigate-diagrams.txt
+++ b/source/diagrams/navigate-diagrams/navigate-diagrams.txt
@@ -5,7 +5,7 @@ Navigate Diagrams and Entities
 This page describes how to navigate your project's diagrams and
 entities.
 
-After you :ref:`Create a Project<rm-create-project-live>`, Relational
+After you :ref:`create a project<rm-create-project-live>`, Relational
 Migrator creates an initial diagram containing the entities and
 relationships in the Relational and MongoDB models.
 
@@ -19,8 +19,8 @@ the top of the workspace.
    Diagram tabs appear in the order that the diagrams were created. You
    cannot reorder diagram tabs.
 
-Change Active Diagram
----------------------
+Change the Active Diagram
+-------------------------
 
 The active diagram is the diagram currently displayed by Relational
 Migrator.

--- a/source/diagrams/navigate-diagrams/navigate-diagrams.txt
+++ b/source/diagrams/navigate-diagrams/navigate-diagrams.txt
@@ -2,9 +2,75 @@
 Navigate Diagrams and Entities
 ==============================
 
+This page describes how to navigate your project's diagrams and
+entities.
+
+After you :ref:`rm-create-project-live`, Relational
+Migrator creates an initial diagram containing the entities and
+relationships in the Relational and MongoDB models.
+
+If you have a large data model, you can create additional diagrams to
+separate the model into smaller subsets. When you have multiple diagrams
+in your project, Relational Migrator lists the diagram names in tabs at
+the top of the workspace.
+
+.. note::
+
+   Diagram tabs appear in the order that the diagrams were created. You
+   cannot reorder diagram tabs.
+
+Change Active Diagram
+---------------------
+
+The active diagram is the diagram currently displayed by Relational
+Migrator.
+
+To change the active diagram, click the tab for the diagram you want to
+view.
+
+Navigate Diagram Entities
+-------------------------
+
+Diagrams are made up of entities. An entity is either a Relational or
+MongoDB database object.
+
+Relational Migrator provides these modes for navigating entities in a
+diagram:
+
+- Pan Mode
+- Multi-Select Mode
+
+Pan Mode
+~~~~~~~~
+
+In Pan Mode, you can click and drag the diagram to navigate to different
+areas. When you click a diagram entity, Relational Migrator shows
+mapping details for that entity in the right pane.
+
+Pan Mode is the default view mode. When you are in Pan Mode, Relational
+Migrator highlights the arrow icon at the top of the diagram.
+
+Multi-Select Mode
+~~~~~~~~~~~~~~~~~
+
+In Multi-Select Mode, you can select multiple diagram entities by
+clicking and dragging the diagram to create a select box. When you
+select multiple entities, Relational Migrator shows the selected
+entities in the right pane. When multiple entities are selected, you
+cannot see any mapping details.
+
+To enter Multi-Select Mode, press and hold :guilabel:`Shift`. When you are in
+Multi-Select Mode, Relational Migrator highlights the box icon at the
+top of the diagram. When you release the shift key, Relational Migrator
+returns to Pan Mode.
+
+Learn More
+----------
+
+To organize diagram entities, see :ref:`rm-apply-layout`
+
 .. toctree::
    :hidden:
    :titlesonly:
 
    /diagrams/navigate-diagrams/apply-layout
-   /diagrams/navigate-diagrams/working-with-entities/working-with-entities

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -1,3 +1,5 @@
+.. _rm-create-project-live:
+
 =================================================
 Create a Project By Connecting to a Live Database
 =================================================


### PR DESCRIPTION
## Description

Navigate Diagrams and Entities Drawer conversion from markdown to snooty.
Tabbed the images so they do not take up as much page real estate, also lightly reworded page content.

## Staging

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30630/diagrams/navigate-diagrams/navigate-diagrams/

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30630/diagrams/navigate-diagrams/apply-layout/


## Jira

https://jira.mongodb.org/browse/DOCSP-30630

## Build

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6489cb1d67a273b81627cd9a