### PR TITLE
(DOCSP-30632): Migrate calculate fields 

### DIFF
--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -69,7 +69,7 @@ Concatenate Strings
 Combine two columns into a single field.
 
 The following example concatenates string values from the ``firstName``
-and ``lastName`` columns:
+and ``lastName`` columns.
 
 Expression:
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -66,6 +66,9 @@ Concatenate Strings
 
 Combine two columns into a single field.
 
+The following example concatenates string values from the ``firstName``
+and ``lastName`` columns:
+
 Expression:
 
 .. code-block:: none
@@ -96,7 +99,11 @@ Output:
 Split Strings
 ~~~~~~~~~~~~~
 
-Split column values based on a specified character.
+Split column values into an array based on a specified character.
+
+The following example splits the ``fullName`` column into an array using
+a space character as a delimiter, and returns the first element of the
+array.
 
 Expression:
 
@@ -127,6 +134,10 @@ Replace Strings
 
 Apply regex patterns to replace string values in a column.
 
+The following example performs a case-insensitive regex search on the
+``fullName`` column for the string ``smith``. If a match is found, the
+expression replaces the matching string with ``Doe``.
+
 Expression:
 
 .. code-block:: none
@@ -156,6 +167,10 @@ Check for String Values
 
 Return true or false for column containing a string value.
 
+The following example returns ``true`` if the value in the ``fullName``
+column includes the string ``Smith``. If the ``fullName`` column does
+not include the string ``Smith``, the expression returns ``false``.
+
 Expression:
 
 .. code-block:: none
@@ -184,6 +199,9 @@ Perform Mathematic Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Perform mathematic operations on column values.
+
+The following example multiplies values from the columns ``coll1`` and
+``coll2``.
 
 Expression:
 
@@ -217,6 +235,9 @@ Assign Values based on Logical Conditions
 
 Assign column values based on logical conditions.
 
+The following example returns ``yes`` if the value of ``coll1`` is
+``3``, and ``no`` if ``coll1`` is a value other than ``3``.
+
 Expression:
 
 .. code-block:: none
@@ -246,6 +267,9 @@ Extract JSON Values
 
 Access data stored as JSON data type with calculated field expressions.
 Requires JSON data type columns (Postgres).
+
+The following example returns the value of the embedded ``state`` field
+inside of the ``Employee`` column values.
 
 Expression:
 
@@ -278,6 +302,9 @@ Access Array Elements
 Access data stored as array data type with calculated fields
 expressions. Requires array data type columns (Postgres or MySQL).
 
+The following example returns the second element of the values in the
+``myArray`` column.
+
 Expression:
 
 .. code-block:: none
@@ -306,6 +333,9 @@ Parse Dates
 ~~~~~~~~~~~
 
 Parse an ISO8601-formatted date string into a date.
+
+The following example converts string values from the ``dateAsString``
+column into dates.
 
 Expression:
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -269,7 +269,7 @@ Access data stored as JSON data type with calculated field expressions.
 Requires JSON data type columns (Postgres).
 
 The following example returns the value of the embedded ``state`` field
-inside of the ``Employee`` column values.
+from values in the ``Employee`` column.
 
 Expression:
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -135,9 +135,15 @@ Expression:
 
 Input:
 
-.. code-block:: none
-    
-   fullName: "John Smith"
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``fullName``
+     - ``John Smith``
 
 Output: 
    
@@ -158,9 +164,15 @@ Expression:
 
 Input:
 
-.. code-block:: none
-    
-   fullName: "John Smith"
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``fullName``
+     - ``John Smith``
 
 Output: 
    
@@ -181,10 +193,18 @@ Expression:
 
 Input:
 
-.. code-block:: none
-    
-   col1: 3
-   col2: 2
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``coll1``
+     - ``3``
+
+   * - ``coll2``
+     - ``2``
 
 Output: 
    
@@ -201,13 +221,19 @@ Expression:
 
 .. code-block:: none
 
-    columns["col1"] === 1 ? "yes" : "no"
+    columns["col1"] === 3 ? "yes" : "no"
 
 Input:
 
-.. code-block:: none
-    
-   col1: 1
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``coll1``
+     - ``3``
 
 Output: 
    
@@ -256,19 +282,25 @@ Expression:
 
 .. code-block:: none
 
-    columns["myArray"][0]
+    columns["myArray"][1]
 
 Input:
 
-.. code-block:: json
-    
-   myArray: ["a","b","c"]
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``myArray``
+     - [ "a", "b", "c" ]
             
 Output: 
    
 .. code-block:: none
 
-   "a"
+   "b"
 
 Parse Dates
 ~~~~~~~~~~~
@@ -283,9 +315,15 @@ Expression:
 
 Input:
 
-.. code-block:: json
-    
-   dateAsString: "2009-02-11"
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``dateAsString``
+     - "2009-02-11"
             
 Output: 
    

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -95,6 +95,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    "John Smith"
 
@@ -125,9 +126,10 @@ Input:
    * - ``fullName``
      - ``John Doe``
 
-Output: 
+Output:
    
 .. code-block:: none
+   :copyable: false
 
    "John"
 
@@ -161,6 +163,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    "John Doe"
 
@@ -194,6 +197,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    true
 
@@ -229,10 +233,11 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    6
 
-Assign Values based on Logical Conditions
+Assign Values Based on Logical Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Assign column values based on logical conditions.
@@ -261,6 +266,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    yes
 
@@ -295,6 +301,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    "California"
 
@@ -328,6 +335,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    "b"
 
@@ -360,6 +368,7 @@ Input:
 Output: 
    
 .. code-block:: none
+   :copyable: false
 
    2009-02-11T0:00:00Z
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -3,3 +3,158 @@
 =====================
 Add Calculated Fields
 =====================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Calculated fields let you create new fields in your documents by
+combining values from existing database columns using JavaScript
+expressions. Calculated fields are evaluated each time a row is
+processed during a sync job.
+
+Before you Begin
+----------------
+
+To create a calculated field, you must define a mapping rule.
+
+To create mapping rules, see the following pages:
+
+- :ref:`rm-new-rules-from-mappings`
+
+- :ref:`rm-create-rule-to-mdb`
+
+- :ref:`rm-create-mapping-rules`
+
+About this Task
+---------------
+
+Calculated field expressions access values from the current source
+database row using the syntax ``columns["COLUMN_NAME"]``.
+
+Steps
+-----
+
+#. From the ``Mapping`` screen, click a table or collection name on the
+   ``schema model`` pane or diagram view.
+
+#. Add a new mapping rule or edit an existing mapping rule.
+
+#. Click the ``+`` icon to the right of the ``All fields`` label.
+
+#. Define a name for the new field in the ``Field Name`` text box.
+
+#. Define a valid JavaScript expression for the new field in the ``Value
+   expression`` text box.
+
+#. Click ``Done``.
+
+#. Click ``Save and close``.
+
+The new field is visible in MongoDB after your next sync job runs.
+
+Examples
+--------
+
+The following table shows examples of JavaScript expressions that you
+can use in calculated fields:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Task Description
+
+     - Expression
+
+     - Input
+
+     - Output
+
+   * - **String Concatenating** Combine two columns into a single field.
+
+     - ``columns["firstName"] + ' ' + columns["lastName"]``
+
+     - firstName: "John", lastName: "Smith"
+
+     - "John Smith"
+
+   * - **String Splitting** Split columns values based on a specific
+       character.
+
+     - ``columns["fullName"].split(' ')[0]``
+
+     - fullName: "John Smith"
+
+     - "John"
+
+   * - **String Replacement** Apply regex patterns to replace string
+       values in a column.
+
+     - ``columns["fullName"].replace(/smith/i, "Doe")``
+
+     - fullName: "John Smith"
+
+     - "John Doe"
+
+   * - **String Includes** Return true or false for column containing a
+       string value.
+
+     - ``columns["fullName"].includes("Smith")``
+
+     - fullName: "John Smith"
+
+     - true
+
+   * - **Number Manipulation** Perform mathematic operations on column
+       values.
+
+     - ``columns["foo"] * columns["bar"]``
+
+     - foo: 1 , bar: 2
+
+     - 2
+
+   * - **Ternaries** Assign column values based on logical conditions.
+
+     - ``columns["foo"] === 1 ? "yes" : "no"``
+
+     - foo: 1
+
+     - "yes"
+
+   * - **Extract JSON Values** Access data stored as JSON data type with
+       calculated field expressions. Requires JSON data type columns
+       (Postgres).
+
+     - ``columns["Employee"].Address.state``
+
+     - Employee: {  name: "Mark",  Address: {  &nbsp;state:"California"  &nbsp;}  }
+
+     - "California"
+
+   * - **Access array elements** Access data stored as array data type
+       with calculated fields expressions. Requires array data type
+       columns (Postgres or MySQL).
+
+     - ``columns["myArray"][0]``
+
+     - myArray: ["a","b","c"]
+
+     - "a"
+   * - **Date Parsing** Parse an ISO8601-formatted date string into a
+       date.
+
+     - ``new Date(columns["dateAsString"])``
+
+     - dateAsString: "2009-02-11"
+
+     - 2009-02-11T0:00:00Z
+
+Learn More
+----------
+
+- :ref:`rm-delete-calulcated-fields`
+- :ref:`rm-edit-calculated-fields`
+- :ref:`rm-view-calculated-fields`

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -76,7 +76,8 @@ can use in calculated fields:
 
      - ``columns["firstName"] + ' ' + columns["lastName"]``
 
-     - firstName: "John", lastName: "Smith"
+     - | firstName: "John", 
+       | lastName: "Smith"
 
      - "John Smith"
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -32,7 +32,7 @@ About this Task
 ---------------
 
 Calculated field expressions access values from the current source
-database row using the syntax ``columns["COLUMN_NAME"]``.
+database row using the syntax ``columns["<COLUMN_NAME>"]``.
 
 Steps
 -----

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -200,8 +200,8 @@ Perform Mathematic Operations
 
 Perform mathematic operations on column values.
 
-The following example multiplies values from the columns ``coll1`` and
-``coll2``.
+The following example multiplies values from the columns ``col1`` and
+``col2``.
 
 Expression:
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -235,8 +235,8 @@ Assign Values based on Logical Conditions
 
 Assign column values based on logical conditions.
 
-The following example returns ``yes`` if the value of ``coll1`` is
-``3``, and ``no`` if ``coll1`` is a value other than ``3``.
+The following example returns ``yes`` if the value of ``col1`` is
+``3``, and ``no`` if ``col1`` is a value other than ``3``.
 
 Expression:
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -165,7 +165,7 @@ Output:
 Check for String Values
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Return true or false for column containing a string value.
+Return true or false based on whether a column contains a string value.
 
 The following example returns ``true`` if the value in the ``fullName``
 column includes the string ``Smith``. If the ``fullName`` column does

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -106,9 +106,15 @@ Expression:
 
 Input:
 
-.. code-block:: none
-    
-   fullName: "John Doe"
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``fullName``
+     - ``John Doe``
 
 Output: 
    

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -58,100 +58,226 @@ The new field is visible in MongoDB after your next sync job runs.
 Examples
 --------
 
-The following table shows examples of JavaScript expressions that you
-can use in calculated fields:
+The following examples show JavaScript expressions that you can use in
+calculated fields:
 
-.. list-table::
-   :header-rows: 1
+Concatenate Strings
+~~~~~~~~~~~~~~~~~~~
 
-   * - Task Description
+Combine two columns into a single field.
 
-     - Expression
+Expression:
 
-     - Input
+.. code-block:: none
 
-     - Output
+    columns["firstName"] + ' ' + columns["lastName"]
 
-   * - **String Concatenating** Combine two columns into a single field.
+Input:
 
-     - ``columns["firstName"] + ' ' + columns["lastName"]``
+.. code-block:: none
+    
+   firstName: "John"
+   lastName: "Smith"
 
-     - | firstName: "John", 
-       | lastName: "Smith"
+Output: 
+   
+.. code-block:: none
 
-     - "John Smith"
+   "John Smith"
 
-   * - **String Splitting** Split columns values based on a specific
-       character.
+Split Strings
+~~~~~~~~~~~~~
 
-     - ``columns["fullName"].split(' ')[0]``
+Split column values based on a specified character.
 
-     - fullName: "John Smith"
+Expression:
 
-     - "John"
+.. code-block:: none
 
-   * - **String Replacement** Apply regex patterns to replace string
-       values in a column.
+    columns["fullName"].split(' ')[0]
 
-     - ``columns["fullName"].replace(/smith/i, "Doe")``
+Input:
 
-     - fullName: "John Smith"
+.. code-block:: none
+    
+   fullName: "John Doe"
 
-     - "John Doe"
+Output: 
+   
+.. code-block:: none
 
-   * - **String Includes** Return true or false for column containing a
-       string value.
+   "John"
 
-     - ``columns["fullName"].includes("Smith")``
+Replace Strings
+~~~~~~~~~~~~~~~
 
-     - fullName: "John Smith"
+Apply regex patterns to replace string values in a column.
 
-     - true
+Expression:
 
-   * - **Number Manipulation** Perform mathematic operations on column
-       values.
+.. code-block:: none
 
-     - ``columns["foo"] * columns["bar"]``
+    columns["fullName"].replace(/smith/i, "Doe")
 
-     - foo: 1 , bar: 2
+Input:
 
-     - 2
+.. code-block:: none
+    
+   fullName: "John Smith"
 
-   * - **Ternaries** Assign column values based on logical conditions.
+Output: 
+   
+.. code-block:: none
 
-     - ``columns["foo"] === 1 ? "yes" : "no"``
+   "John Doe"
 
-     - foo: 1
+Check for String Values
+~~~~~~~~~~~~~~~~~~~~~~~
 
-     - "yes"
+Return true or false for column containing a string value.
 
-   * - **Extract JSON Values** Access data stored as JSON data type with
-       calculated field expressions. Requires JSON data type columns
-       (Postgres).
+Expression:
 
-     - ``columns["Employee"].Address.state``
+.. code-block:: none
 
-     - Employee: {  name: "Mark",  Address: {  &nbsp;state:"California"  &nbsp;}  }
+    columns["fullName"].includes("Smith")
 
-     - "California"
+Input:
 
-   * - **Access array elements** Access data stored as array data type
-       with calculated fields expressions. Requires array data type
-       columns (Postgres or MySQL).
+.. code-block:: none
+    
+   fullName: "John Smith"
 
-     - ``columns["myArray"][0]``
+Output: 
+   
+.. code-block:: none
 
-     - myArray: ["a","b","c"]
+   true
 
-     - "a"
-   * - **Date Parsing** Parse an ISO8601-formatted date string into a
-       date.
+Perform Mathematic Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-     - ``new Date(columns["dateAsString"])``
+Perform mathematic operations on column values.
 
-     - dateAsString: "2009-02-11"
+Expression:
 
-     - 2009-02-11T0:00:00Z
+.. code-block:: none
+
+    columns["col1"] * columns["col2"]
+
+Input:
+
+.. code-block:: none
+    
+   col1: 3
+   col2: 2
+
+Output: 
+   
+.. code-block:: none
+
+   6
+
+Assign Values based on Logical Conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Assign column values based on logical conditions.
+
+Expression:
+
+.. code-block:: none
+
+    columns["col1"] === 1 ? "yes" : "no"
+
+Input:
+
+.. code-block:: none
+    
+   col1: 1
+
+Output: 
+   
+.. code-block:: none
+
+   yes
+
+Extract JSON Values
+~~~~~~~~~~~~~~~~~~~
+
+Access data stored as JSON data type with calculated field expressions.
+Requires JSON data type columns (Postgres).
+
+Expression:
+
+.. code-block:: none
+
+    columns["Employee"].Address.state
+
+Input:
+
+.. code-block:: json
+    
+   {
+      Employee: { 
+         name: "Mark",
+         Address: {
+            state: "California"
+         } 
+      }
+   }
+            
+Output: 
+   
+.. code-block:: none
+
+   "California"
+
+Access Array Elements
+~~~~~~~~~~~~~~~~~~~~~
+
+Access data stored as array data type with calculated fields
+expressions. Requires array data type columns (Postgres or MySQL).
+
+Expression:
+
+.. code-block:: none
+
+    columns["myArray"][0]
+
+Input:
+
+.. code-block:: json
+    
+   myArray: ["a","b","c"]
+            
+Output: 
+   
+.. code-block:: none
+
+   "a"
+
+Parse Dates
+~~~~~~~~~~~
+
+Parse an ISO8601-formatted date string into a date.
+
+Expression:
+
+.. code-block:: none
+
+    new Date(columns["dateAsString"])
+
+Input:
+
+.. code-block:: json
+    
+   dateAsString: "2009-02-11"
+            
+Output: 
+   
+.. code-block:: none
+
+   2009-02-11T0:00:00Z
 
 Learn More
 ----------

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -364,6 +364,6 @@ Output:
 Learn More
 ----------
 
-- :ref:`rm-delete-calulcated-fields`
+- :ref:`rm-delete-calculated-fields`
 - :ref:`rm-edit-calculated-fields`
 - :ref:`rm-view-calculated-fields`

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -37,21 +37,23 @@ database row using the syntax ``columns["<COLUMN_NAME>"]``.
 Steps
 -----
 
-#. From the ``Mapping`` screen, click a table or collection name on the
-   ``schema model`` pane or diagram view.
+#. From the :guilabel:`Mapping` screen, click a table or collection name
+   on the :guilabel:`schema model` pane or diagram view.
 
 #. Add a new mapping rule or edit an existing mapping rule.
 
-#. Click the ``+`` icon to the right of the ``All fields`` label.
+#. Click the :guilabel:`+` icon to the right of the :guilabel:`All
+   fields` label.
 
-#. Define a name for the new field in the ``Field Name`` text box.
+#. Define a name for the new field in the :guilabel:`Field Name` text
+   box.
 
 #. Define a valid JavaScript expression for the new field in the ``Value
    expression`` text box.
 
-#. Click ``Done``.
+#. Click :guilabel:`Done`.
 
-#. Click ``Save and close``.
+#. Click :guilabel:`Save and close`.
 
 The new field is visible in MongoDB after your next sync job runs.
 

--- a/source/mapping-rules/calculated-fields/add-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/add-calculated-fields.txt
@@ -74,10 +74,18 @@ Expression:
 
 Input:
 
-.. code-block:: none
-    
-   firstName: "John"
-   lastName: "Smith"
+.. list-table::
+   :header-rows: 1
+   :widths: 10 10
+
+   * - Column
+     - Value
+
+   * - ``firstName``
+     - ``John``
+
+   * - ``lastName``
+     - ``Smith``
 
 Output: 
    

--- a/source/mapping-rules/calculated-fields/calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/calculated-fields.txt
@@ -1,7 +1,60 @@
+.. _rm-calculated-fields:
+
 =================
 Calculated Fields
 =================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Calculated fields are JavaScript expressions that let you create new
+fields based on relational source columns. You can use calculated fields
+to transform your relational database source columns into customized
+MongoDB fields.
+
+Use Cases
+---------
+
+You can use calculated fields to perform the following actions:
+
+- Modify string values
+
+- Split or concatenate fields
+
+- Perform arithmetic operations such as addition and subtraction
+
+Behavior
+--------
+
+You can use JavaScript code in a calculated field.
+
+You cannot use third-party JavaScript libraries in calculated fields.
+
+Calculated fields have the following characteristics:
+
+- They are optionally added to the list of fields belonging to a mapping
+  rule.
+
+- They only access data from a table row's column values.
+
+- They serve as a transformation layer as you migrate your data to
+  MongoDB.
+
+Tasks
+-----
+
+- To create calculated fields, see :ref:`rm-add-calculated-fields`.
+
+- To create mapping rules, see the following pages:
+
+  - :ref:`rm-new-rules-from-mappings`
+
+  - :ref:`rm-create-rule-to-mdb`
+
+  - :ref:`rm-create-mapping-rules`
 
 .. toctree::
    :titlesonly:

--- a/source/mapping-rules/calculated-fields/calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/calculated-fields.txt
@@ -43,8 +43,8 @@ Calculated fields have the following characteristics:
 - They serve as a transformation layer as you migrate your data to
   MongoDB.
 
-Tasks
------
+Get Started
+-----------
 
 - To create calculated fields, see :ref:`rm-add-calculated-fields`.
 

--- a/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
@@ -4,6 +4,12 @@
 Delete Calculated Fields
 ========================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 You can delete an existing calculated field and remove the field from
 your mapping rule. Deleted calculated fields do not update in future
 sync job runs.

--- a/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
@@ -34,8 +34,8 @@ To delete a calculated field:
 
 #. Click :guilabel:`Save and close`.
 
-The next time that you run a sync job, the field will not be added to
-the MongoDB collection.
+The next time that you run a sync job, the deleted field will not be
+updated in the MongoDB collection.
 
 Learn More
 ----------

--- a/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
@@ -1,3 +1,5 @@
+.. _rm-delete-calulcated-fields:
+
 ========================
 Delete Calculated Fields
 ========================

--- a/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
@@ -17,8 +17,6 @@ sync job runs.
 Steps
 -----
 
-To delete a calculated field:
-
 #. From the :guilabel:`Mapping` screen, click a table or collection name
    on the :guilabel:`Schema Model` pane or diagram view.
 
@@ -34,8 +32,8 @@ To delete a calculated field:
 
 #. Click :guilabel:`Save and close`.
 
-The next time that you run a sync job, the deleted field will not be
-updated in the MongoDB collection.
+The next time that you run a sync job, the deleted field is not updated
+in the MongoDB collection.
 
 Learn More
 ----------

--- a/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/delete-calculated-fields.txt
@@ -1,5 +1,39 @@
-.. _rm-delete-calulcated-fields:
+.. _rm-delete-calculated-fields:
 
 ========================
 Delete Calculated Fields
 ========================
+
+You can delete an existing calculated field and remove the field from
+your mapping rule. Deleted calculated fields do not update in future
+sync job runs.
+
+Steps
+-----
+
+To delete a calculated field:
+
+#. From the :guilabel:`Mapping` screen, click a table or collection name
+   on the :guilabel:`Schema Model` pane or diagram view.
+
+#. Click the pencil icon next to the mapping rule that contains the
+   calculated field you want to delete.
+
+#. Click the vertical :guilabel:`...` icon next to the calculated field you want
+   to delete.
+
+#. Click :guilabel:`Delete calculated field`.
+
+#. Click :guilabel:`Delete` to confirm you want to delete the field.
+
+#. Click :guilabel:`Save and close`.
+
+The next time that you run a sync job, the field will not be added to
+the MongoDB collection.
+
+Learn More
+----------
+
+- :ref:`rm-add-calculated-fields`
+- :ref:`rm-edit-calculated-fields`
+- :ref:`rm-view-calculated-fields`

--- a/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
@@ -5,7 +5,7 @@ Edit Calculated Fields
 ======================
 
 You can update the JavaScript expression used in existing calcualted
-fields. Newly edited calculated fields are visible in MongoDB after your
+fields. Newly edited calculated fields are updated in MongoDB after your
 next sync job runs.
 
 Steps

--- a/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
@@ -1,3 +1,5 @@
+.. _rm-edit-calculated-fields:
+
 ======================
 Edit Calculated Fields
 ======================

--- a/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
@@ -4,6 +4,12 @@
 Edit Calculated Fields
 ======================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 You can update the JavaScript expression used in existing calcualted
 fields. Newly edited calculated fields are updated in MongoDB after your
 next sync job runs.

--- a/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
@@ -17,8 +17,6 @@ next sync job runs.
 Steps
 -----
 
-To edit a calculated field:
-
 #. From the :guilabel:`Mapping` screen, click a table or collection name
    on the :guilabel:`Schema Model` pane or diagram view.
 

--- a/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/edit-calculated-fields.txt
@@ -3,3 +3,37 @@
 ======================
 Edit Calculated Fields
 ======================
+
+You can update the JavaScript expression used in existing calcualted
+fields. Newly edited calculated fields are visible in MongoDB after your
+next sync job runs.
+
+Steps
+-----
+
+To edit a calculated field:
+
+#. From the :guilabel:`Mapping` screen, click a table or collection name
+   on the :guilabel:`Schema Model` pane or diagram view.
+
+#. Click the pencil icon next to the mapping rule that contains the
+   calculated field you want to edit.
+
+#. Click the vertical :guilabel:`...` icon next to the calculated field
+   you want to edit.
+
+#. Click :guilabel:`Edit calculated field` and update the JavaScript
+   expression.
+
+#. Click :guilabel:`Done`.
+
+#. Click :guilabel:`Save and close`.
+
+The edited field is updated after your next sync job runs.
+
+Learn More
+----------
+
+- :ref:`rm-add-calculated-fields`
+- :ref:`rm-delete-calculated-fields`
+- :ref:`rm-view-calculated-fields`

--- a/source/mapping-rules/calculated-fields/view-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/view-calculated-fields.txt
@@ -10,14 +10,19 @@ View Calculated Fields
    :depth: 2
    :class: singlecol
 
-You can view an existing calculated field to see the JavaScript expression.
+You can view an existing calculated field the see the JavaScript
+expression that generates calculated values.
 
 About this Task
 ---------------
 
-When you view a calculated field in a mapping rule, the name is shown in
-*italics* and does not have an include/exclude checkbox or stated data
-type.
+When you view a calculated field in a mapping rule:
+
+- The field name is shown in *italics*.
+
+- The field does not have an include/exclude checkbox.
+
+- The field does not state its data type.
 
 Steps
 -----

--- a/source/mapping-rules/calculated-fields/view-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/view-calculated-fields.txt
@@ -1,3 +1,5 @@
+.. _rm-view-calculated-fields:
+
 ======================
 View Calculated Fields
 ======================

--- a/source/mapping-rules/calculated-fields/view-calculated-fields.txt
+++ b/source/mapping-rules/calculated-fields/view-calculated-fields.txt
@@ -3,3 +3,36 @@
 ======================
 View Calculated Fields
 ======================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+You can view an existing calculated field to see the JavaScript expression.
+
+About this Task
+---------------
+
+When you view a calculated field in a mapping rule, the name is shown in
+*italics* and does not have an include/exclude checkbox or stated data
+type.
+
+Steps
+-----
+
+#. From the :guilabel:`Mapping` screen, click a table or collection name on the
+   :guilabel:`schema model` pane or diagram view.
+
+#. Click the pencil icon next to the mapping rule you want to view.
+
+#. Hover over the :guilabel:`i` icon next to the calculated field you
+   want to view. The JavaScript expression displays in a tooltip window.
+
+Learn More
+----------
+
+- :ref:`rm-add-calculated-fields`
+- :ref:`rm-delete-calculated-fields`
+- :ref:`rm-edit-calculated-fields`

--- a/source/mapping-rules/new-rules-suggested-mappings.txt
+++ b/source/mapping-rules/new-rules-suggested-mappings.txt
@@ -1,3 +1,5 @@
+.. _rm-new-rules-from-mappings:
+
 ====================================
 Create Rules From Suggested Mappings
 ====================================

--- a/source/mapping-rules/new-rules-to-mongodb.txt
+++ b/source/mapping-rules/new-rules-to-mongodb.txt
@@ -1,3 +1,5 @@
+.. _rm-create-rule-to-mdb:
+
 ======================
 Create Rule To MongoDB
 ======================


### PR DESCRIPTION
### Description

Add new pages for Calculated Fields

### Build Log

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=648b354567a273b816815ecb

### Staging

- [Calculated Fields](https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30632/mapping-rules/calculated-fields/calculated-fields/)
- [Add Calculated Fields](https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30632/mapping-rules/calculated-fields/add-calculated-fields/)
  - Note, for this page I ended up reworking the examples section. Previously, all of the examples were in a [single table](http://docs-migrator.s3-website-us-east-1.amazonaws.com/main/Mapping-Rules/calculated-fields/add-calculated-fields/#examples), but the columns were too narrow to parse. I moved each example to its own sub-section. 
- [View Calculated Fields](https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30632/mapping-rules/calculated-fields/view-calculated-fields/)
- [Edit Calcuated Fields](https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30632/mapping-rules/calculated-fields/edit-calculated-fields/)
- [Delete Calculated Fields](https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30632/mapping-rules/calculated-fields/delete-calculated-fields/)

### JIRA

https://jira.mongodb.org/browse/DOCSP-30632