### PR TITLE
DOCSP-30906 update to rpm in RHEL

### DIFF
--- a/source/installation/install-on-a-single-machine/install-rhel.txt
+++ b/source/installation/install-on-a-single-machine/install-rhel.txt
@@ -17,7 +17,7 @@ IP and port.
 Steps
 -----
 
-1. Download the latest ``.deb`` binary from the 
+1. Download the latest ``.rpm`` binary from the 
    `release page <https://migrator-installer-repository.s3.ap-southeast-2.amazonaws.com/index.html>`__.
 
 #. Install Relational Migrator.


### PR DESCRIPTION
Correct first step of Install RHEL to say `.rpm` binary.

STAGING: https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-30906/installation/install-on-a-single-machine/install-rhel/

JIRA: https://jira.mongodb.org/browse/DOCSP-30906

BUILD: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6494a4d5423952aeb9811536