### PR TITLE
DOCSP-31276 xdb driver

### DIFF
--- a/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
+++ b/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
@@ -41,6 +41,9 @@ If you are migrating from an Oracle database:
 
 - Download `21.6.0.0 of odjbc11.jar from the Oracle 21c <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`_. 
 
+- (Optional) If you are migrating tables that contain the ``XML`` type, you must also download the 
+  `xdb.jar <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`_ driver. 
+
 Get Started
 -----------
 

--- a/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
+++ b/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
@@ -41,8 +41,8 @@ If you are migrating from an Oracle database:
 
 - Download `21.6.0.0 of odjbc11.jar from the Oracle 21c <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`_. 
 
-- (Optional) If you are migrating tables that contain the ``XML`` type, you must also download the 
-  `xdb.jar <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`_ driver. 
+- (Optional) To migrate tables that contain the ``XML`` type, you must also download the 
+  `xdb.jar <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`__ driver. 
 
 Get Started
 -----------

--- a/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
+++ b/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
@@ -41,7 +41,7 @@ If you are migrating from an Oracle database:
 
 - Download `21.6.0.0 of odjbc11.jar from the Oracle 21c <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`_. 
 
-- (Optional) To migrate tables that contain the ``XML`` type, you must also download the 
+- (Optional) To migrate tables that contain the ``XMLType`` type, you must also download the 
   `xdb.jar <https://www.oracle.com/database/technologies/appdev/jdbc-drivers-archive.html>`__ driver. 
 
 Get Started


### PR DESCRIPTION
Added xdb driver bullet for migrating tables that contain the `XML` type. 

STAGING: https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-31276/installation/install-on-a-single-machine/install-on-a-single-machine/#behavior 

JIRA: https://jira.mongodb.org/browse/DOCSP-31276

BUILD LOG: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b02a8a423952aeb9003c8a