### PR TITLE
DOCSP-27098 File location ref page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -14,6 +14,7 @@ toc_landing_pages = [
 "installation/install-on-an-unattended-server/debian-server-installation/debian-server-installation",
 "installation/install-on-an-unattended-server/windows-server-installation/windows-server-installation",
 "installation/install-on-an-unattended-server/rhel-centos-server-installation/rhel-centos-server-installation",
+"installation/file-location",
 "projects/projects",
 "mapping-rules/mapping-rules",
 "mapping-rules/mapping-rule-options/mapping-rule-options",

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -48,3 +48,4 @@ For instructions on installing Relational Migrator, see the following pages:
 
    /installation/install-on-a-single-machine/install-on-a-single-machine
    /installation/install-on-an-unattended-server/install-on-an-unattended-server
+   /installation/file-location

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -48,19 +48,19 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 50 50
+   :widths: 70 30
 
    * - File location 
      - Description
 
-   * - File Location for your application configuration.
-     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
+     - File Location for your application configuration.
 
-   * - File location for your driver downloads.  
-     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
+     - File location for your driver downloads.
 
-   * - File location for your log information.
-     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
+     - File location for your log information.
 
 Linux
 -----

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -12,8 +12,8 @@ Relational Migrator File Locations
    :depth: 1
    :class: singlecol
 
-Review the location of files needed when working with Relational Migrator. 
-Their location varies according to the OS you are working with. 
+Use Relational Migrator file locations when: modifying application configuration 
+files, deploying additional JDBC drivers, or reviewing log files. 
 
 Mac
 ---
@@ -24,11 +24,11 @@ The file locations for the Mac OS:
   
   ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
 
-- **Driver downloads**
+- **Downloaded JDBC Drivers**
 
-  ``~/Library/Application Support/MongoDB/Relational Migrator/Drivers``
+  ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
 
-- **Log information**
+- **Log files**
   
   ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
 
@@ -39,15 +39,17 @@ The file locations for the Windows OS:
 
 - **Configuration file**
 
-  ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
+  ``c:\Users\<username>\AppData\Local\MongoDB\Relational 
+  Migrator\Data\user.properties``
 
-- **Driver downloads**
+- **Downloaded JDBC Drivers**
 
   ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
 
-- **Log information**
+- **Log files**
 
-  ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
+  ``c:\Users\<username>\AppData\Local\MongoDB\Relational 
+  Migrator\Data\Logs\migrator.log``
 
 Linux
 -----
@@ -58,11 +60,11 @@ The file locations for the Linux OS:
 
   ``~/Migrator/user.properties``
 
-- **Driver downloads**
+- **Downloaded JDBC Drivers**
 
   ``/opt/mongodb-relational-migrator/lib/app/lib``
 
-- **Log information**
+- **Log files**
 
   ``~/Migrator/Logs/migrator.log``
 

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -32,14 +32,14 @@ The file locations for the Mac OS:
    * - File location 
      - Description
  
-   * - ~/Library/Application Support/MongoDB/Relational Migrator/user.properties 
-     - Location for application configuration.  
+   * - ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
+     - File Location for your application configuration.  
 
-   * - /Library/Application Support/MongoDB/Relational Migrator/Drivers
-     - Location for driver downloads. 
+   * - ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
+     - File location for your driver downloads.
 
-   * - ~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log
-     - Location for log information. 
+   * - ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
+     - File location for your log information. 
 
 Windows
 -------
@@ -52,14 +52,14 @@ The file locations for the Windows OS:
    * - File location 
      - Description
 
-   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties 
-     - Location for application configuration.
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
+     - File Location for your application configuration.
 
-   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers
-     - Location for driver downloads.
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
+     - File location for your driver downloads.
 
-   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log
-     - Location for log information. 
+   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
+     - File location for your log information.
 
 Linux
 -----
@@ -72,14 +72,14 @@ The file locations for the Linux OS:
    * - File location 
      - Description
 
-   * - ~/Migrator/user.properties
-     - Location for application configuration.
+   * - ``~/Migrator/user.properties``
+     - File Location for your application configuration.
 
-   * - /opt/mongodb-relational-migrator/lib/app/lib
-     - Location for driver downloads.
+   * - ``/opt/mongodb-relational-migrator/lib/app/lib``
+     - File location for your driver downloads.
 
-   * - ~/Migrator/Logs/migrator.log
-     - Location for log information. 
+   * - ``~/Migrator/Logs/migrator.log``
+     - File location for your log information.
 
 Learn More
 ----------

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -49,7 +49,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :width: 60 40
+   :width: 50 50
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -12,29 +12,23 @@ Relational Migrator File Locations
    :depth: 1
    :class: singlecol
 
-The following page provides the location of files needed when working with 
-Relational Migrator. The location of the files varies according to the OS 
-you are working with. 
-
-.. note::
-
-    This information is correct for Relational Migrator v1.0.35 and higher (earlier 
-    versions store files in different locations).
+Review the location of files needed when working with Relational Migrator. 
+Their location varies according to the OS you are working with. 
 
 Mac
 ---
 
 The file locations for the Mac OS:
 
-- :guilabel:`Configuration file`
+- **Configuration file**
   
   ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
 
-- :guilabel:`Driver downloads`
+- **Driver downloads**
 
-  ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
+  ``~/Library/Application Support/MongoDB/Relational Migrator/Drivers``
 
-- :guilabel:`Log information`
+- **Log information**
   
   ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
 
@@ -43,15 +37,15 @@ Windows
 
 The file locations for the Windows OS:
 
-- :guilabel:`Configuration file`
+- **Configuration file**
 
   ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
 
-- :guilabel:`Driver downloads`
+- **Driver downloads**
 
   ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
 
-- :guilabel:`Log information`
+- **Log information**
 
   ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
 
@@ -60,15 +54,15 @@ Linux
 
 The file locations for the Linux OS: 
 
-- :guilabel:`Configuration file`
+- **Configuration file**
 
   ``~/Migrator/user.properties``
 
-- :guilabel:`Driver downloads`
+- **Driver downloads**
 
   ``/opt/mongodb-relational-migrator/lib/app/lib``
 
-- :guilabel:`Log information`
+- **Log information**
 
   ``~/Migrator/Logs/migrator.log``
 

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -49,6 +49,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
+   :width: 60 40
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -40,41 +40,28 @@ Windows
 
 The file locations for the Windows OS:
 
-.. list-table::
-   :header-rows: 1
-   :widths: 20 70 
+- :guilabel:`Configuration file`
+  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
 
-   * - File location 
-     - Description
+- :guilabel:`Driver downloads`
+  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
 
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
-     - File Location for your application configuration.
-
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
-     - File location for your driver downloads.
-
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
-     - File location for your log information.
+- :guilabel:`Log information`
+  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
 
 Linux
 -----
 
 The file locations for the Linux OS: 
 
-.. list-table::
-   :header-rows: 1
+- :guilabel:`Configuration file`
+  - ``~/Migrator/user.properties``
 
-   * - File location 
-     - Description
+- :guilabel:`Driver downloads`
+    - ``/opt/mongodb-relational-migrator/lib/app/lib``
 
-   * - ``~/Migrator/user.properties``
-     - File Location for your application configuration.
-
-   * - ``/opt/mongodb-relational-migrator/lib/app/lib``
-     - File location for your driver downloads.
-
-   * - ``~/Migrator/Logs/migrator.log``
-     - File location for your log information.
+- :guilabel:`Log information`
+  - ``~/Migrator/Logs/migrator.log``
 
 Learn More
 ----------

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -48,19 +48,19 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 60 40
+   :widths: 40 60
 
    * - File location 
      - Description
 
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
-     - File Location for your application configuration.
+   * - File Location for your application configuration.
+     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
 
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
-     - File location for your driver downloads.
+   * - File location for your driver downloads.  
+     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
 
-   * - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
-     - File location for your log information.
+   * - File location for your log information.
+     - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
 
 Linux
 -----

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -27,13 +27,16 @@ Mac
 The file locations for the Mac OS:
 
 - :guilabel:`Configuration file`
-  - ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
+  
+  ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
 
 - :guilabel:`Driver downloads`
-  - ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
+
+  ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
 
 - :guilabel:`Log information`
-  - ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
+  
+  ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
 
 Windows
 -------
@@ -41,13 +44,16 @@ Windows
 The file locations for the Windows OS:
 
 - :guilabel:`Configuration file`
-  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
+
+  ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties``
 
 - :guilabel:`Driver downloads`
-  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
+
+  ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``
 
 - :guilabel:`Log information`
-  - ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
+
+  ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log``
 
 Linux
 -----
@@ -55,13 +61,16 @@ Linux
 The file locations for the Linux OS: 
 
 - :guilabel:`Configuration file`
-  - ``~/Migrator/user.properties``
+
+  ``~/Migrator/user.properties``
 
 - :guilabel:`Driver downloads`
-    - ``/opt/mongodb-relational-migrator/lib/app/lib``
+
+  ``/opt/mongodb-relational-migrator/lib/app/lib``
 
 - :guilabel:`Log information`
-  - ``~/Migrator/Logs/migrator.log``
+
+  ``~/Migrator/Logs/migrator.log``
 
 Learn More
 ----------

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -28,6 +28,7 @@ The file locations for the Mac OS:
 
 .. list-table::
    :header-rows: 1
+   :widths: 75 25
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -28,7 +28,6 @@ The file locations for the Mac OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 60 40
 
    * - File location 
      - Description
@@ -49,7 +48,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :width: 40 60
+   :widths: 50 50
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -48,7 +48,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 70 30
+   :widths: 20 70 
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -48,7 +48,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 40 60
+   :widths: 50 50
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -48,7 +48,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 50 50
+   :widths: 60 40
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -26,20 +26,14 @@ Mac
 
 The file locations for the Mac OS:
 
-.. list-table::
-   :header-rows: 1
+- :guilabel:`Configuration file`
+  - ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
 
-   * - File location 
-     - Description
- 
-   * - ``~/Library/Application Support/MongoDB/Relational Migrator/user.properties``
-     - File Location for your application configuration.  
+- :guilabel:`Driver downloads`
+  - ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
 
-   * - ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``
-     - File location for your driver downloads.
-
-   * - ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
-     - File location for your log information. 
+- :guilabel:`Log information`
+  - ``~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log``
 
 Windows
 -------

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -28,7 +28,7 @@ The file locations for the Mac OS:
 
 .. list-table::
    :header-rows: 1
-   :widths: 75 25
+   :widths: 60 40
 
    * - File location 
      - Description

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -1,0 +1,89 @@
+.. _file-location:
+
+==================================
+Relational Migrator File Locations
+==================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+The following page provides the location of files needed when working with 
+Relational Migrator. The location of the files varies according to the OS 
+you are working with. 
+
+.. note::
+
+    This information is correct for Relational Migrator v1.0.35 and higher (earlier 
+    versions store files in different locations).
+
+Mac
+---
+
+The file locations for the Mac OS:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File location 
+     - Description
+ 
+   * - ~/Library/Application Support/MongoDB/Relational Migrator/user.properties 
+     - Location for application configuration.  
+
+   * - /Library/Application Support/MongoDB/Relational Migrator/Drivers
+     - Location for driver downloads. 
+
+   * - ~/Library/Application Support/MongoDB/Relational Migrator/Logs/migrator.log
+     - Location for log information. 
+
+Windows
+-------
+
+The file locations for the Windows OS:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File location 
+     - Description
+
+   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\user.properties 
+     - Location for application configuration.
+
+   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers
+     - Location for driver downloads.
+
+   * - c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Logs\migrator.log
+     - Location for log information. 
+
+Linux
+-----
+
+The file locations for the Linux OS: 
+
+.. list-table::
+   :header-rows: 1
+
+   * - File location 
+     - Description
+
+   * - ~/Migrator/user.properties
+     - Location for application configuration.
+
+   * - /opt/mongodb-relational-migrator/lib/app/lib
+     - Location for driver downloads.
+
+   * - ~/Migrator/Logs/migrator.log
+     - Location for log information. 
+
+Learn More
+----------
+
+- :ref:`Installation on a Single Machine <single-machine-install>` 
+
+- :ref:`Installation on an Unattended Server <unattended-server>`

--- a/source/installation/file-location.txt
+++ b/source/installation/file-location.txt
@@ -49,7 +49,7 @@ The file locations for the Windows OS:
 
 .. list-table::
    :header-rows: 1
-   :width: 50 50
+   :width: 40 60
 
    * - File location 
      - Description

--- a/source/installation/install-on-a-single-machine/install-mac.txt
+++ b/source/installation/install-on-a-single-machine/install-mac.txt
@@ -53,6 +53,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`Install on RHEL/CentOS <single-rhel>`
 
 - :ref:`Install on Ubuntu/Debian <single-ubuntu>`

--- a/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
+++ b/source/installation/install-on-a-single-machine/install-on-a-single-machine.txt
@@ -57,6 +57,8 @@ Learn More
 
 - :ref:`Install on an Unattended Server <unattended-server>`
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 
 .. toctree::
    :hidden:

--- a/source/installation/install-on-a-single-machine/install-rhel.txt
+++ b/source/installation/install-on-a-single-machine/install-rhel.txt
@@ -67,6 +67,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`Install on Mac <single-mac>`
 
 - :ref:`Install on Ubuntu/Debian <single-ubuntu>`

--- a/source/installation/install-on-a-single-machine/install-ubuntu.txt
+++ b/source/installation/install-on-a-single-machine/install-ubuntu.txt
@@ -67,6 +67,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`Install on Mac <single-mac>`
 
 - :ref:`Install on RHEL/CentOS <single-rhel>`

--- a/source/installation/install-on-a-single-machine/install-windows.txt
+++ b/source/installation/install-on-a-single-machine/install-windows.txt
@@ -57,6 +57,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`Install on Mac <single-mac>`
 
 - :ref:`Install on RHEL/CentOS <single-rhel>`

--- a/source/installation/install-on-an-unattended-server/debian-server-installation/install-debian-server.txt
+++ b/source/installation/install-on-an-unattended-server/debian-server-installation/install-debian-server.txt
@@ -111,6 +111,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`RHEL/CentOS Systems Installation <rhel-install>`
 
 - :ref:`Windows Server Installation <windows-install>`

--- a/source/installation/install-on-an-unattended-server/install-on-an-unattended-server.txt
+++ b/source/installation/install-on-an-unattended-server/install-on-an-unattended-server.txt
@@ -51,6 +51,8 @@ Learn More
 
 - :ref:`Install on a Single Machine <single-machine-install>`
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 
 .. toctree::
    :titlesonly:

--- a/source/installation/install-on-an-unattended-server/rhel-centos-server-installation/install-rhel-server.txt
+++ b/source/installation/install-on-an-unattended-server/rhel-centos-server-installation/install-rhel-server.txt
@@ -112,6 +112,8 @@ Next Steps
 Learn More
 ----------
 
+- :ref:`Relational Migrator File Locations <file-location>` 
+
 - :ref:`Debian Systems Installation <debian-install>`
 
 - :ref:`Windows Server Installation <windows-install>`

--- a/source/installation/install-on-an-unattended-server/windows-server-installation/install-windows-server.txt
+++ b/source/installation/install-on-an-unattended-server/windows-server-installation/install-windows-server.txt
@@ -81,3 +81,5 @@ Learn More
 - :ref:`Debian Systems Installation <debian-install>`
 
 - :ref:`RHEL/CentOS Systems Installation <rhel-install>`
+
+- :ref:`Relational Migrator File Locations <file-location>`  


### PR DESCRIPTION
Create reference page for file locations used in install pages.

STAGING: https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-27098/installation/file-location/#windows

JIRA: https://jira.mongodb.org/browse/DOCSP-27098?filter=-1

BUILD: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b181178d53f9c4af1cf6fa