### PR TITLE
DOCSP-27700 Manage the Relation Model Refactor

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -32,5 +32,5 @@ toc_landing_pages = [
 ]
 
 [constants]
-DDL = ":abbr:`DDL Data Definition Language`"
+DDL = ":abbr:`Data Definition Language`"
 

--- a/snooty.toml
+++ b/snooty.toml
@@ -32,5 +32,5 @@ toc_landing_pages = [
 ]
 
 [constants]
-DDL = ":abbr:`Data Definition Language`"
+ddl = ":abbr:`Data Definition Language`"
 

--- a/snooty.toml
+++ b/snooty.toml
@@ -31,5 +31,6 @@ toc_landing_pages = [
 "code-generation/code-generation"
 ]
 
-# [constants]
-# constant = "value"
+[constants]
+DDL = ":abbr:`DDL Data Definition Language`"
+

--- a/snooty.toml
+++ b/snooty.toml
@@ -32,5 +32,5 @@ toc_landing_pages = [
 ]
 
 [constants]
-ddl = ":abbr:`Data Definition Language`"
+ddl = ":abbr:`DDL (Data Definition Language)`"
 

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -9,11 +9,11 @@ Manage the Relational Model
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-You can use the :guilabel:`Manage` button on the :guilabel:`Schema model` pane to 
-make changes to the schemas or tables you want to include in 
+You can use the :guilabel:`Manage` button on the :guilabel:`Schema model` 
+pane to make changes to the schemas or tables you want to include in 
 your migration project. You can also connect to the source database 
 or use a DDL file to refresh the list of available tables.
 
@@ -28,40 +28,43 @@ the :guilabel:`Manage` button.
 
 #. Click the check box next to the schema or schemas you are migrating. 
 
-#. To expand the tables in a schema, click ``>``.
+#. To expand the tables in a schema, click :icon-fa5:`chevron-right`.
 
    Select the tables you want to add or remove from your migration.
 
 #. Click :guilabel:`Save`. 
 
    Changes from your relational database are reflected in the main 
-   Relational Migrator diagram and included in future migration jobs.
+   Relational Migrator diagram and included in future sync jobs.
 
 Refresh Schema Changes
 ----------------------
 
-If your relational database table structure changes, use the :guilabel:`Refresh Schema` button to let Relational Migrator know. 
+If your relational database table structure changes, use the 
+:guilabel:`Refresh Schema` button to let Relational Migrator know. 
 
-1. From the :guilabel:`Mapping` screen, click the :guilabel:`Manage` button on the 
-   :guilabel:`Schema model` pane.
+1. From the :guilabel:`Mapping` screen, click the :guilabel:`Manage` 
+   button on the :guilabel:`Schema model` pane.
 
-#. Click the :guilabel:`Refresh schema` button on the Manage relational model modal.
+#. Click the :guilabel:`Refresh schema` button on the Manage 
+   relational model modal.
 
-#. Select either :ref:`Connect DB <connect-db>` or :ref:`Import DDL File  <import-ddl-file>`.
+#. Select either :ref:`Connect DB <connect-db>` or 
+   :ref:`Import DDL File  <import-ddl-file>`.
 
 .. _connect-db:
 
 Connect DB 
 ~~~~~~~~~~~
 
-:guilabel:`Connect DB` rescans the schema. Changes in foreign key relations or data 
-types for the underlying tables are read into Migrator.
+:guilabel:`Connect DB` rescans the schema. Changes in foreign key 
+relations or data types for the underlying tables are read into Migrator.
 
 1. Input the :guilabel:`JDBC URI`, :guilabel:`Username` and :guilabel:`Password` 
    for the database instance you are connecting to. 
 
-   The account used can be different from the credentials you used when creating 
-   the project.
+   The account used can be different from the credentials you used when 
+   creating the project.
 
    .. note::
    
@@ -74,7 +77,7 @@ types for the underlying tables are read into Migrator.
    
    Any changes from your relational database are reflected in 
    the main Relational Migrator diagram and included in future 
-   migration jobs.
+   sync jobs.
 
 .. _import-ddl-file:
 
@@ -102,4 +105,4 @@ data types for the underlying tables are read into Migrator.
 #. Click :guilabel:`Save`. 
 
    Any changes from your relational database are reflected in the main 
-   Relational Migrator diagram and included in future migration jobs.
+   Relational Migrator diagram and included in future sync jobs.

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -15,7 +15,7 @@ Manage the Relational Model
 You can use the :guilabel:`Manage` button on the :guilabel:`Schema model` 
 pane to make changes to the schemas or tables you want to include in 
 your migration project. You can also connect to the source database 
-or use a DDL file to refresh the list of available tables.
+or use a {+ddl+} file to refresh the list of available tables.
 
 Add or Remove Tables from a Project
 -----------------------------------
@@ -84,7 +84,7 @@ relations or data types for the underlying tables are read into Migrator.
 Import DDL File
 ~~~~~~~~~~~~~~~
 
-:guilabel:`Import DDL File` opens a file prompt that accepts a DDL file of the 
+:guilabel:`Import DDL File` opens a file prompt that accepts a {+ddl+} file of the 
 relational schema you are migrating. Any changes in the foreign key relations or 
 data types for the underlying tables are read into Migrator.
 

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -28,7 +28,8 @@ the :guilabel:`Manage` button.
 
 #. Click the check box next to the schema or schemas you are migrating. 
 
-#. To expand the tables in a schema, click :icon-fa5:`chevron-right`.
+#. To expand the tables in a schema, click the :icon-fa5:`chevron-right`
+   button.
 
    Select the tables you want to add or remove from your migration.
 

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -49,19 +49,19 @@ If your relational database table structure changes, use the
 #. Click the :guilabel:`Refresh schema` button on the Manage 
    relational model modal.
 
-#. Select either :ref:`Connect DB <connect-db>` or 
+#. Select either :ref:`Connect to database <connect-to-db>` or 
    :ref:`Import DDL File  <import-ddl-file>`.
 
-.. _connect-db:
+.. _connect-to-db:
 
-Connect DB 
-~~~~~~~~~~~
+Connect to database
+~~~~~~~~~~~~~~~~~~~
 
-:guilabel:`Connect DB` rescans the schema. Changes in foreign key 
+:guilabel:`Connect to database` rescans the schema. Changes in foreign key 
 relations or data types for the underlying tables are read into Migrator.
 
-1. Input the :guilabel:`JDBC URI`, :guilabel:`Username` and :guilabel:`Password` 
-   for the database instance you are connecting to. 
+1. Input the :guilabel:`JDBC URI`, :guilabel:`Username` and 
+   :guilabel:`Password` for the database instance you are connecting to. 
 
    The account used can be different from the credentials you used when 
    creating the project.

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -98,7 +98,7 @@ data types for the underlying tables are read into Migrator.
    - PostgreSQL
    - SQL Server
 
-#. Choose a file or drag and drop a DDL statement file.
+#. Choose a file or drag and drop a {+DDL+} statement file.
 
 #. Click :guilabel:`Import`.
 

--- a/source/projects/manage-relational-connection.txt
+++ b/source/projects/manage-relational-connection.txt
@@ -98,7 +98,7 @@ data types for the underlying tables are read into Migrator.
    - PostgreSQL
    - SQL Server
 
-#. Choose a file or drag and drop a {+DDL+} statement file.
+#. Choose a file or drag and drop a {+ddl+} statement file.
 
 #. Click :guilabel:`Import`.
 


### PR DESCRIPTION
## Description

Small updates and improvements to the Manage the Relation Model page. Also updated `Connect DB` -> `Connect to database` since the UI has changed and adjusted terminology `migration jobs` -> `sync jobs` for consistency.

## Staging

https://docs-mongodbcom-staging.corp.mongodb.com/docs-relational-migrator/docsworker-xlarge/DOCSP-27700/projects/manage-relational-connection/

## Jira

https://jira.mongodb.org/browse/DOCSP-27700

## Build

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64d6476c67dbe91010dcc431