### PR TITLE
DOCSP-33925 Fix Relational Connection String 404s

### DIFF
--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -101,7 +101,7 @@ details:
    To learn more about Oracle connection strings, see:
 
    - `Oracle JDBC Developer's Guide and Reference <https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/JDBC-Thin-features.html>`__
-   - `Connection String Attributes <https://docs.oracle.com/cd/E85694_01/ODPNT/ConnectionConnectionString.htm>`__
+   - `Connection String Attributes <https://docs.oracle.com/cd/E85694_01/ODPNT/ConnectionConnectionString.htm#GUID-DF4ED9A3-1AAF-445D-AEEF-016E6CD5A0C0__BABBAGJJ>`__
 
 PostgreSQL
 ----------

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -100,7 +100,7 @@ details:
 
    To learn more about Oracle connection strings, see:
 
-   - `Oracle JDBC Developer's Guide and Reference <https://docs.oracle.com/cd/B28359_01/java.111/b31224/jdbcthin.htm>`__
+   - `Oracle JDBC Developer's Guide and Reference <https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/JDBC-Thin-features.html>`__
    - `Connection String Attributes <https://docs.oracle.com/cd/E85694_01/ODPNT/ConnectionConnectionString.htm#GUID-DF4ED9A3-1AAF-445D-AEEF-016E6CD5A0C0__BABBAGJJ>`__
 
 PostgreSQL

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -101,7 +101,7 @@ details:
    To learn more about Oracle connection strings, see:
 
    - `Oracle JDBC Developer's Guide and Reference <https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/JDBC-Thin-features.html>`__
-   - `Connection String Attributes <https://docs.oracle.com/cd/E85694_01/ODPNT/ConnectionConnectionString.htm#GUID-DF4ED9A3-1AAF-445D-AEEF-016E6CD5A0C0__BABBAGJJ>`__
+   - `Connection String Attributes <https://docs.oracle.com/cd/E85694_01/ODPNT/ConnectionConnectionString.htm>`__
 
 PostgreSQL
 ----------

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -63,8 +63,8 @@ details:
 
    To learn more about MySQL connection strings, see:
 
-   - `MySQL Connection URL Syntax <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html>`__
-   - `Connection Configuration Properties <https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html>`__
+   - `MySQL Connection URL Syntax <https://dev.mysql.com/doc/connector-j/en/connector-j-reference-jdbc-url-format.html>`__
+   - `Connection Configuration Properties <https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html>`__
 
 Oracle
 ------


### PR DESCRIPTION
## DESCRIPTION

Fixed two links that were 404ing on the MySQL Connection string section.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-33925/connection-strings/relational-database-connection-strings/#mysql

## JIRA

https://jira.mongodb.org/browse/DOCSP-33925

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653facb7bd8a7a95793afebe

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)