### PR TITLE
DOCSP-33437 Add Data Modeling Links to Mapping Rules Page

### DIFF
--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -20,8 +20,8 @@ valid :ref:`relational database connection string and credentials <rm-relational
 Application Data Models 
 -----------------------
 
-Before designing your application's mapping rules and data models, consider 
-the following documentation:
+Before designing your application's mapping rules and data models, 
+review the following documentation:
 
 - Best practices outlined in the :ref:`data-modeling-patterns`.
 - The following MongoDB blog posts: 

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -17,6 +17,14 @@ migrated to and how the columns should be mapped to fields in
 MongoDB documents. Mapping rules are created inside a project after you have provided a 
 valid :ref:`relational database connection string and credentials <rm-relational-database-connection-strings>`.
 
+Application Data Models 
+-----------------------
+
+When designing your mapping rules, consider 
+the best practices outlined in the :ref:`data-modeling-patterns` 
+documentation and the `Building with Patterns blog post 
+<https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
+
 Mapping Direction Preference
 ----------------------------
 

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -22,8 +22,9 @@ Application Data Models
 
 When designing your mapping rules, consider 
 the best practices outlined in the :ref:`data-modeling-patterns` 
-documentation and the `Building with Patterns blog post 
-<https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
+documentation and the `Building with Patterns
+<https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
+blog post.
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -26,7 +26,7 @@ the following documentation:
 - Best practices outlined in the :ref:`data-modeling-patterns`.
 - The MongoDB blog posts: 
   - `Building with Patterns
-  <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
+  <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
 
   - The MongoDB `Summary of Schema Design Anti-Patterns and How to Spot Them
     <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -22,10 +22,11 @@ MongoDB Schema Design Patterns
 
 Schema design patterns in MongoDB shape how your data is organized. 
 Good schema design practices ensure efficient storage, retrieval, and 
-manipulation of your data which improve the performance and scalability
-of your MongoDB deployment. Relational Migrator allows you to make key 
-schema design decisions such as combining multiple tables into a 
-single collection or embedding data in your documents.
+manipulation of your data. These design decisions can improve the 
+performance and scalability of your MongoDB deployment. Relational 
+Migrator allows you to make key schema design decisions such as 
+combining multiple tables into a single collection or embedding data 
+in your documents.
 
 For an overview of schema design best practices, review the following 
 documentation:

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -20,16 +20,17 @@ valid :ref:`relational database connection string and credentials <rm-relational
 Application Data Models 
 -----------------------
 
-Before designing your applications mapping rules and data models, consider 
+Before designing your application's mapping rules and data models, consider 
 the following documentation:
 
-- Best practices outlined in the :ref:`data-modeling-patterns` 
-  documentation.
-- The MongoDB `Building with Patterns
+- Best practices outlined in the :ref:`data-modeling-patterns`.
+- The MongoDB blog posts: 
+  - `Building with Patterns
   <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
-  blog post.
-- `A Summary of Schema Design Anti-Patterns and How to Spot Them
-  <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__.
+
+  - The MongoDB `Summary of Schema Design Anti-Patterns and How to Spot Them
+    <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__
+    blog post.
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -21,10 +21,15 @@ Application Data Models
 -----------------------
 
 When designing your mapping rules, consider 
-the best practices outlined in the :ref:`data-modeling-patterns` 
-documentation and the `Building with Patterns
-<https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
-blog post.
+the following documentation:
+
+- Best practices outlined in the :ref:`data-modeling-patterns` 
+  documentation.
+- The MongoDB `Building with Patterns
+  <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
+  blog post.
+- `<A Summary of Schema Design Anti-Patterns and How to Spot Them>
+   https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/`__.
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -20,7 +20,7 @@ valid :ref:`relational database connection string and credentials <rm-relational
 Application Data Models 
 -----------------------
 
-When designing your mapping rules, consider 
+Before designing your applications mapping rules and data models, consider 
 the following documentation:
 
 - Best practices outlined in the :ref:`data-modeling-patterns` 

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -22,13 +22,13 @@ MongoDB Schema Design Patterns
 
 Data modeling in MongoDB shapes how data is organized, accessed, and 
 queried. These decisions influence performance and 
-scalability of your MongoDB deployment. Effective modeling ensures 
-efficient storage, retrieval, and manipulation of your data. 
+scalability of your MongoDB deployment. Good data modeling practices 
+ensure efficient storage, retrieval, and manipulation of your data. 
 Relational Migrator allows you to make key decisions such as combining 
 multiple tables into a single collection or embedding data in your documents.
 
-Before designing your application's mapping rules and data models, 
-review the following documentation:
+For an overview of data modeling best practices review the following 
+documentation:
 
 - :ref:`data-modeling-patterns`.
 

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -25,8 +25,9 @@ the following documentation:
 
 - Best practices outlined in the :ref:`data-modeling-patterns`.
 - The MongoDB blog posts: 
+
   - `Building with Patterns
-  <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
+    <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
 
   - The MongoDB `Summary of Schema Design Anti-Patterns and How to Spot Them
     <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -27,7 +27,7 @@ ensure efficient storage, retrieval, and manipulation of your data.
 Relational Migrator allows you to make key decisions such as combining 
 multiple tables into a single collection or embedding data in your documents.
 
-For an overview of schema design best practices review the following 
+For an overview of schema design best practices, review the following 
 documentation:
 
 - :ref:`data-modeling-patterns`.

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -20,12 +20,12 @@ valid :ref:`relational database connection string and credentials <rm-relational
 MongoDB Schema Design Patterns
 ------------------------------
 
-Schema design patterns in MongoDB shape how data is organized, accessed, and 
-queried. Your schema design influences the performance and 
-scalability of your MongoDB deployment. Good schema design practices 
-ensure efficient storage, retrieval, and manipulation of your data. 
-Relational Migrator allows you to make key decisions such as combining 
-multiple tables into a single collection or embedding data in your documents.
+Schema design patterns in MongoDB shape how your data is organized. 
+Good schema design practices ensure efficient storage, retrieval, and 
+manipulation of your data which promote the performance and scalability
+of your MongoDB deployment. Relational Migrator allows you to make key 
+schema design decisions such as combining multiple tables into a 
+single collection or embedding data in your documents.
 
 For an overview of schema design best practices, review the following 
 documentation:

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -20,14 +20,14 @@ valid :ref:`relational database connection string and credentials <rm-relational
 MongoDB Schema Design Patterns
 ------------------------------
 
-Data modeling in MongoDB shapes how data is organized, accessed, and 
-queried. These decisions influence performance and 
-scalability of your MongoDB deployment. Good data modeling practices 
+Schema design patterns in MongoDB shape how data is organized, accessed, and 
+queried. Your schema design influences the performance and 
+scalability of your MongoDB deployment. Good schema design practices 
 ensure efficient storage, retrieval, and manipulation of your data. 
 Relational Migrator allows you to make key decisions such as combining 
 multiple tables into a single collection or embedding data in your documents.
 
-For an overview of data modeling best practices review the following 
+For an overview of schema design best practices review the following 
 documentation:
 
 - :ref:`data-modeling-patterns`.

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -23,14 +23,13 @@ Application Data Models
 Before designing your application's mapping rules and data models, 
 review the following documentation:
 
-- Best practices outlined in the :ref:`data-modeling-patterns`.
-- The following MongoDB blog posts: 
+- :ref:`data-modeling-patterns`.
 
-  - `Building with Patterns
-    <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
+- `Building with Patterns
+  <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
 
-  - `Summary of Schema Design Anti-Patterns and How to Spot Them
-    <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__.
+- `Summary of Schema Design Anti-Patterns and How to Spot Them
+  <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__.
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -22,7 +22,7 @@ MongoDB Schema Design Patterns
 
 Schema design patterns in MongoDB shape how your data is organized. 
 Good schema design practices ensure efficient storage, retrieval, and 
-manipulation of your data which promote the performance and scalability
+manipulation of your data which improve the performance and scalability
 of your MongoDB deployment. Relational Migrator allows you to make key 
 schema design decisions such as combining multiple tables into a 
 single collection or embedding data in your documents.

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -17,8 +17,15 @@ migrated to and how the columns should be mapped to fields in
 MongoDB documents. Mapping rules are created inside a project after you have provided a 
 valid :ref:`relational database connection string and credentials <rm-relational-database-connection-strings>`.
 
-Application Data Models 
------------------------
+MongoDB Schema Design Patterns
+------------------------------
+
+Data modeling in MongoDB shapes how data is organized, accessed, and 
+queried. These decisions influence performance and 
+scalability of your MongoDB deployment. Effective modeling ensures 
+efficient storage, retrieval, and manipulation of your data. 
+Relational Migrator allows you to make key decisions such as combining 
+multiple tables into a single collection or embedding data in your documents.
 
 Before designing your application's mapping rules and data models, 
 review the following documentation:

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -28,8 +28,8 @@ the following documentation:
 - The MongoDB `Building with Patterns
   <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__
   blog post.
-- `<A Summary of Schema Design Anti-Patterns and How to Spot Them>
-   https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/`__.
+- `A Summary of Schema Design Anti-Patterns and How to Spot Them
+  <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__.
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -29,9 +29,9 @@ the following documentation:
   - `Building with Patterns
     <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
 
-  - The MongoDB `Summary of Schema Design Anti-Patterns and How to Spot Them
+  - `Summary of Schema Design Anti-Patterns and How to Spot Them
     <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__
-    blog post.
+    .
 
 Mapping Direction Preference
 ----------------------------

--- a/source/mapping-rules/mapping-rules.txt
+++ b/source/mapping-rules/mapping-rules.txt
@@ -24,14 +24,13 @@ Before designing your application's mapping rules and data models, consider
 the following documentation:
 
 - Best practices outlined in the :ref:`data-modeling-patterns`.
-- The MongoDB blog posts: 
+- The following MongoDB blog posts: 
 
   - `Building with Patterns
     <https://www.mongodb.com/blog/post/building-with-patterns-a-summary>`__.
 
   - `Summary of Schema Design Anti-Patterns and How to Spot Them
-    <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__
-    .
+    <https://www.mongodb.com/developer/products/mongodb/schema-design-anti-pattern-summary/>`__.
 
 Mapping Direction Preference
 ----------------------------


### PR DESCRIPTION
## DESCRIPTION

Adding links to data modeling content for the mapping rules page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-33437/mapping-rules/mapping-rules/#application-data-models

## JIRA

https://jira.mongodb.org/browse/DOCSP-33437


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=655bd0f25b686d6bd940dd38

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)