### PR TITLE
DOCSP-34755 Add Connection String Option Note

### DIFF
--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -23,9 +23,10 @@ About this Task
 ---------------
 
 - Relational Migrator supports all connection string options except 
-  ``appName``. Relational Migrator overrides the ``appName`` connection
-  string option when connecting to your MongoDB deployment. For details 
-  on MongoDB connection string options, see :ref:`<mongodb-uri>`.
+  :urioption:`appName`. Relational Migrator overrides the ``appName`` 
+  connection string option when connecting to your MongoDB deployment. 
+  For details on MongoDB connection string options, see 
+  :ref:`<mongodb-uri>`.
 
 - Relational Migrator can use both Atlas and on-premises URIs. This page 
   provides separate instructions for each deployment type.

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -25,7 +25,8 @@ About this Task
 - Relational Migrator supports all connection string options except 
   ``appName``. Relational Migrator overrides the ``appName`` connection
   string option when connecting to your MongoDB deployment. For details 
-  on MongoDB connection string options, see :ref:`mongodb-uri`.
+  on MongoDB connection string options, see :ref:`connection string 
+  <mongodb-uri>`.
 
 - Relational Migrator can use both Atlas and on-premises URIs. This page 
   provides separate instructions for each deployment type.

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -25,8 +25,7 @@ About this Task
 - Relational Migrator supports all connection string options except 
   ``appName``. Relational Migrator overrides the ``appName`` connection
   string option when connecting to your MongoDB deployment. For details 
-  on MongoDB connection string options, see :ref:`connection string 
-  <mongodb-uri>`.
+  on MongoDB connection string options, see :ref:`<mongodb-uri>`.
 
 - Relational Migrator can use both Atlas and on-premises URIs. This page 
   provides separate instructions for each deployment type.

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -19,8 +19,16 @@ the procedure to make an authenticated user account and the Uniform Resource
 Identifier (URI) formats for defining connections to your target 
 MongoDB database. 
 
-Relational Migrator can use both Atlas and on-premises URIs. This page 
-provides separate instructions for each deployment type.
+About this Task
+---------------
+
+- Relational Migrator supports all connection string options except 
+  ``appName``. Relational Migrator overrides the ``appName`` connection
+  string option when connecting to your MongoDB deployment. For details 
+  on MongoDB connection string options, see :ref:`mongodb-uri`.
+
+- Relational Migrator can use both Atlas and on-premises URIs. This page 
+  provides separate instructions for each deployment type.
 
 Atlas
 -----


### PR DESCRIPTION
## DESCRIPTION

Add details to the MongoDB connection string page that Relational Migrator supports all connection string options except appname when connecting to MongoDB.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-34755/connection-strings/mongodb-database-connection-strings/

## JIRA

https://jira.mongodb.org/browse/DOCSP-34755


## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6579fe387a5cb5fef5d1efe2

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)