### PR TITLE
DOCSP-29066 Add Help Menu Context to UI Page

### DIFF
--- a/source/includes/fact-get-help-menu.rst
+++ b/source/includes/fact-get-help-menu.rst
@@ -1,0 +1,3 @@
+View links for documentation, contact support, community forums, 
+product feedback, and a :guilabel:`Replay Product Tour` button to
+trigger the onscreen tutorial of the user interface.

--- a/source/includes/fact-get-help-menu.rst
+++ b/source/includes/fact-get-help-menu.rst
@@ -1,3 +1,4 @@
 View links for documentation, contact support, community forums, 
-product feedback, and a :guilabel:`Replay Product Tour` button to
-trigger the onscreen tutorial of the user interface.
+product feedback. The menu also includes a 
+:guilabel:`Replay Product Tour` button to trigger the onscreen 
+tutorial of the user interface.

--- a/source/includes/fact-get-help-menu.rst
+++ b/source/includes/fact-get-help-menu.rst
@@ -1,4 +1,4 @@
-View links for documentation, contact support, community forums, 
+View links for documentation, support, community forums, and
 product feedback. The menu also includes a 
-:guilabel:`Replay Product Tour` button to trigger the onscreen 
+:guilabel:`Replay Product Tour` button to view the onscreen 
 tutorial of the user interface.

--- a/source/mapping-rules/schema-mapping.txt
+++ b/source/mapping-rules/schema-mapping.txt
@@ -82,7 +82,7 @@ objects for the migrated tables. The results look like this:
          "Quantity": 1,
          "Product": {
            "ProductID": 1,
-           "Name": "Mark Porter Action Figure",
+           "Name": "MongoDB 5.0 Action Figure",
            "Price": 50
          }
        },

--- a/source/projects/overview.txt
+++ b/source/projects/overview.txt
@@ -51,3 +51,4 @@ UI Elements
 
    * - Get Help Menu
      -  .. include:: /includes/fact-get-help-menu.rst
+

--- a/source/projects/overview.txt
+++ b/source/projects/overview.txt
@@ -48,3 +48,6 @@ UI Elements
    * - Right Pane 
      - View, edit, delete, and add mapping rules. Select and rename fields 
        included in a mapping rule. Add and remove table filters.
+
+   * - Get Help Menu
+     -  .. include:: /includes/fact-get-help-menu.rst


### PR DESCRIPTION
## DESCRIPTION

Add help menu context to UI page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-29066/projects/overview/

## JIRA

https://jira.mongodb.org/browse/DOCSP-29066

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65958590dcc0144a51b5fd49

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)