### PR TITLE
DOCSP-34352 Add MySQL Data Prerequisite page

### DIFF
--- a/source/includes/fact-my-sql-setup-user-permission-step.rst
+++ b/source/includes/fact-my-sql-setup-user-permission-step.rst
@@ -1,0 +1,26 @@
+.. step:: (Optional) Set up user permissions
+
+   The following code creates a new MySQL service account 
+   for Relational Migrator to connect to the MySQL 
+   instance. 
+
+   Create a service account:
+
+   .. code-block:: sql
+      :copyable: true
+
+      CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+
+   Grant the required permissions to the service account:
+
+   .. code-block:: sql
+      :copyable: true
+      
+      GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+
+   Apply the user privilege changes:
+
+   .. code-block:: sql
+      :copyable: true
+
+      FLUSH PRIVILEGES; 

--- a/source/includes/fact-my-sql-setup-user-permission-step.rst
+++ b/source/includes/fact-my-sql-setup-user-permission-step.rst
@@ -16,7 +16,9 @@
    .. code-block:: sql
       :copyable: true
       
-      GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+      GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT 
+      ON *.* 
+      TO 'user'@'%';
 
    Apply the user privilege changes:
 

--- a/source/includes/fact-my-sql-setup-user-permission-step.rst
+++ b/source/includes/fact-my-sql-setup-user-permission-step.rst
@@ -6,25 +6,25 @@
    account to connect to Relational Migrator with the appropriate 
    permissions.
 
-   Create a service account:
+   a. Create a service account:
 
-   .. code-block:: sql
-      :copyable: true
+      .. code-block:: sql
+         :copyable: true
 
-      CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+         CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
 
-   Grant the required permissions to the service account:
+   #. Grant the required permissions to the service account:
 
-   .. code-block:: sql
-      :copyable: true
-      
-      GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT 
-      ON *.* 
-      TO 'user'@'%';
+      .. code-block:: sql
+         :copyable: true
+         
+         GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT 
+         ON *.* 
+         TO 'user'@'%';
 
-   Apply the user privilege changes:
+   #. Apply the user privilege changes:
 
-   .. code-block:: sql
-      :copyable: true
+      .. code-block:: sql
+         :copyable: true
 
-      FLUSH PRIVILEGES; 
+         FLUSH PRIVILEGES; 

--- a/source/includes/fact-my-sql-setup-user-permission-step.rst
+++ b/source/includes/fact-my-sql-setup-user-permission-step.rst
@@ -2,7 +2,9 @@
 
    The following code creates a new MySQL service account 
    for Relational Migrator to connect to the MySQL 
-   instance. 
+   instance. Alternatively, you can use an existing MySQL service 
+   account to connect to Relational Migrator with the appropriate 
+   permissions.
 
    Create a service account:
 

--- a/source/includes/fact-short-sync-job-desc.rst
+++ b/source/includes/fact-short-sync-job-desc.rst
@@ -1,0 +1,3 @@
+- Snapshot which migrates all the data and then stops.
+- Continuous which runs a snapshot and then enters a CDC stage to 
+  continuously replicate changes.

--- a/source/includes/fact-short-sync-job-desc.rst
+++ b/source/includes/fact-short-sync-job-desc.rst
@@ -1,3 +1,3 @@
-- Snapshot which migrates all the data and then stops.
-- Continuous which runs a snapshot and then enters a CDC stage to 
-  continuously replicate changes.
+- Snapshot sync jobs migrate all the data and then stops.
+- Continuous sync job run a snapshot and then enter a CDC stage to 
+  continuously replicate data changes.

--- a/source/prerequisites.txt
+++ b/source/prerequisites.txt
@@ -21,4 +21,5 @@ database for use with Relational Migrator.
    /prerequisites/oracle
    /prerequisites/postgres
    /prerequisites/sql-server
+   /prerequisites/sybase
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -167,10 +167,10 @@ Steps
 
                .. note::
 
-                  If your running MySQL on AWS RDS, you must enable 
-                  automated backups for binary logging. If automated 
-                  backups are not enabled, ``Binlog`` is disabled even
-                  if setting the values in the configuration file.
+                  If you're running MySQL on AWS RDS and `automated backups 
+                  <https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html>`__
+                  are not enabled, ``Binlog`` will be disabled, even if 
+                  the values are set in the configuration file. 
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -40,11 +40,11 @@ Steps
    .. tab:: Continuous Jobs
       :tabid: enable-continuous-jobs
 
-         Running continuous jobs on Relational Migrator 
-         requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
-         to be enabled on your MySQL instance. The binary log (Binlog) 
-         records all operations in the order they are committed to the 
-         database. 
+      Running continuous jobs on Relational Migrator 
+      requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
+      to be enabled on your MySQL instance. The binary log (Binlog) 
+      records all operations in the order they are committed to the 
+      database. 
 
       .. procedure::
          :style: normal
@@ -83,7 +83,7 @@ Steps
                         SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 
                         FROM information_schema.global_variables WHERE variable_name='log_bin';
-         
+
          .. step:: Locate the ``mycnf`` configuration file
 
             a. To locate the config file for your MySQL instance run the 
@@ -120,29 +120,29 @@ Steps
                file add the following lines, replace the ``XXXXX`` value 
                with the ``server_id`` from the previous query:
 
-                  .. tab:: MySql 8.x
-                     :tabid: mysql-8x
+               .. tab:: MySql 8.x
+                  :tabid: mysql-8x
 
-                     .. code-block::
-                        :copyable: true
+                  .. code-block::
+                     :copyable: true
 
-                        server-id         = XXXXX
-                        log_bin                     = mysql-bin
-                        binlog_format               = ROW
-                        binlog_row_image            = FULL
-                        binlog_expire_logs_seconds  = 864000
+                     server-id         = XXXXX
+                     log_bin                     = mysql-bin
+                     binlog_format               = ROW
+                     binlog_row_image            = FULL
+                     binlog_expire_logs_seconds  = 864000
 
-                  .. tab:: MySql 5.x
-                     :tabid: mysql-5x
+               .. tab:: MySql 5.x
+                  :tabid: mysql-5x
 
-                     .. code-block:: 
-                        :copyable: true
+                  .. code-block:: 
+                     :copyable: true
 
-                        server-id         = XXXXX
-                        log_bin                     = mysql-bin
-                        binlog_format               = ROW
-                        binlog_row_image            = FULL
-                        expire_log_days = 10 
+                     server-id         = XXXXX
+                     log_bin                     = mysql-bin
+                     binlog_format               = ROW
+                     binlog_row_image            = FULL
+                     expire_log_days = 10 
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -167,7 +167,7 @@ Steps
 
                .. note::
 
-                  If your running MySQL on AWS RDS, you must enable 
+                  If you're running MySQL on AWS RDS, you must enable 
                   automated backups for binary logging. If automated 
                   backups are not enabled, ``Binlog`` is disabled even
                   if setting the values in the configuration file.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -18,7 +18,7 @@ Database Administrator (DBA) review the commands in this script and
 perform their execution on the database server. The 
 MySQL Server configurations depend on the type of sync job:
 
-.. include:: /includes/pfact-short-sync-job-desc.rst
+.. include:: /includes/fact-short-sync-job-desc.rst
 
 For details on supported versions of MySQL, see 
 :ref:`supported-databases`.
@@ -53,10 +53,14 @@ Steps
 
          .. step:: Manually verify Binlog is enabled
 
-               
                Relational Migrator automatically checks this setting for 
                you. To manually check the if the ``Binlog`` option is 
                enabled, use the queries below for your version of MySQL:
+
+               .. note:: 
+
+                  ``Binlog`` is automatically enabled by default 
+                  on MySQL ``8.x`` versions.
 
                .. tabs::
 
@@ -79,6 +83,33 @@ Steps
                         SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 
                         FROM information_schema.global_variables WHERE variable_name='log_bin';
+         
+         .. step:: Locate the ``mycnf`` configuration file
+
+            To locate the config file for your MySQL instance run the 
+            following mysqld command from the terminal:
+
+            a. 
+               mysql --help | grep cnf //macOS / Linux
+               mysql --help | findstr cnf // Windows
+
+            b. Under the ``under [mysqld] section`` add the following 
+               lines:
+
+               server_id               = 1
+               log_bin                 = /var/log/mysql/mysql-bin.log
+               max_binlog_size         = 100M
+               binlog_format           = mixed
+               binlog_expire_logs_seconds = 864000
+
+
+               For MySQL ``5.x``:
+
+               server_id               = 1
+               log_bin                 = /var/log/mysql/mysql-bin.log
+               max_binlog_size         = 100M
+               binlog_format           = mixed
+               expire_log_days = 10 
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -40,9 +40,9 @@ Steps
    .. step:: (Optional) User permissions setup 
 
       Relational Migrator generates SQL that can be executed to enable 
-      ``Binlog`` for the source MySQL database. The following optional 
-      code creates a new MySQL account for Relational Migrator to connect
-      to the MySQL instance. 
+      ``Binlog`` for the source MySQL database. The following 
+      code creates a new MySQL service account for Relational Migrator 
+      to connect to the MySQL instance. 
 
       Create a service account:
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -15,8 +15,8 @@ some configuration changes. If Relational Migrator determines the
 database needs configuration changes, it automatically generates a 
 SQL script with the required changes. It is recommended to have a 
 Database Administrator (DBA) review the commands in this script and 
-perform their execution on the database server. This topic 
-MySQL Server configuration depends on the type of sync job:
+perform their execution on the database server. The 
+MySQL Server configurations depend on the type of sync job:
 
 .. include:: /includes/fact-short-sync-job-desc.rst
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -37,7 +37,7 @@ Steps
 .. procedure::
    :style: normal
 
-   .. step:: (Optional) User permissions and job setup 
+   .. step:: (Optional) User permissions setup 
 
       Relational Migrator generates SQL that can be executed to enable 
       ``Binlog`` for the source MySQL database. The following optional 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -86,11 +86,8 @@ Steps
          
          .. step:: Locate the ``mycnf`` configuration file
 
-            To locate the config file for your MySQL instance run the 
-            following mysqld command from the terminal:
-
-            a. 
-
+            a. To locate the config file for your MySQL instance run the 
+               following ``mysqld`` command from the terminal:
 
                .. tab:: MacOS / Linux
                      :tabid: macos-linux
@@ -119,9 +116,9 @@ Steps
                   information_schema.global_variables 
                   WHERE variable_name='server_id';
 
-            #. Under the ``mysqld`` section add the following 
-               lines, replace the ``XXXXX`` value with the ``server_id``
-               from the previous query:
+            #. Under the ``mysqld`` section of your mySQL configuration 
+               file add the following lines, replace the ``XXXXX`` value 
+               with the ``server_id`` from the previous query:
 
                   .. tab:: MySql 8.x
                      :tabid: mysql-8x
@@ -146,7 +143,7 @@ Steps
                         binlog_format               = ROW
                         binlog_row_image            = FULL
                         expire_log_days = 10 
-            
+
 Learn More
 ----------
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -51,7 +51,7 @@ Steps
 
          .. include:: /includes/fact-my-sql-setup-user-permission-step.rst
 
-         .. step:: Manually verify Binlog is enabled
+         .. step:: (Optional) Manually verify Binlog is enabled
 
                Relational Migrator automatically checks this setting for 
                you. To manually check the if the ``Binlog`` option is 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -90,26 +90,62 @@ Steps
             following mysqld command from the terminal:
 
             a. 
-               mysql --help | grep cnf //macOS / Linux
-               mysql --help | findstr cnf // Windows
-
-            b. Under the ``under [mysqld] section`` add the following 
-               lines:
-
-               server_id               = 1
-               log_bin                 = /var/log/mysql/mysql-bin.log
-               max_binlog_size         = 100M
-               binlog_format           = mixed
-               binlog_expire_logs_seconds = 864000
 
 
-               For MySQL ``5.x``:
+               .. tab:: MacOS / Linux
+                     :tabid: macos-linux
 
-               server_id               = 1
-               log_bin                 = /var/log/mysql/mysql-bin.log
-               max_binlog_size         = 100M
-               binlog_format           = mixed
-               expire_log_days = 10 
+                     .. code-block:: 
+                        :copyable: true
+
+                        mysql --help | grep cnf
+
+               .. tab:: Windows
+                     :tabid: windows
+
+                     .. code-block:: 
+                        :copyable: true
+
+                        mysql --help | findstr cnf
+
+            #. Run the following SQL query to get the ``server_id`` 
+               value for your deployment:
+               
+               .. code-block:: sql
+                  :copyable: true
+
+                  SELECT variable_value 
+                  FROM 
+                  information_schema.global_variables 
+                  WHERE variable_name='server_id';
+
+            #. Under the ``mysqld`` section add the following 
+               lines, replace the ``XXXXX`` value with the ``server_id``
+               from the previous query:
+
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
+
+                     .. code-block::
+                        :copyable: true
+
+                        server-id         = XXXXX
+                        log_bin                     = mysql-bin
+                        binlog_format               = ROW
+                        binlog_row_image            = FULL
+                        binlog_expire_logs_seconds  = 864000
+
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
+
+                     .. code-block:: 
+                        :copyable: true
+
+                        server-id         = XXXXX
+                        log_bin                     = mysql-bin
+                        binlog_format               = ROW
+                        binlog_row_image            = FULL
+                        expire_log_days = 10 
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -102,14 +102,6 @@ Steps
 
                .. tabs::
 
-                  .. tab:: MacOS / Linux
-                     :tabid: macos-linux
-
-                     .. code-block:: 
-                        :copyable: true
-
-                        mysql --help | grep cnf
-
                   .. tab:: Windows
                      :tabid: windows
 
@@ -118,17 +110,26 @@ Steps
 
                         mysql --help | findstr cnf
 
+                  .. tab:: MacOS / Linux
+                     :tabid: macos-linux
+
+                     .. code-block:: 
+                        :copyable: true
+
+                        mysql --help | grep cnf
+
+
             #. Under the ``mysqld`` section of your mySQL configuration 
                file add the following lines. Replace the ``XXXXX`` value 
                with the ``server_id`` from the previous query:
 
-            .. note::
+               .. note::
 
-               If your running MySQL on AWS RDS, you must enable 
-               automated backups for binary logging. If automated 
-               backups are not enabled, ``binlog`` is disabled even
-               if setting the values in the configuration file.
-               
+                  If your running MySQL on AWS RDS, you must enable 
+                  automated backups for binary logging. If automated 
+                  backups are not enabled, ``binlog`` is disabled even
+                  if setting the values in the configuration file.
+                  
                .. tab:: MySql 8.x
                   :tabid: mysql-8x
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-mysql:
 
 =============================
-Configure MySQL for Sync Jobs
+MySQL Migration Prerequisites
 =============================
 
 .. contents:: On this page

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -84,9 +84,20 @@ Steps
 
                         FROM information_schema.global_variables WHERE variable_name='log_bin';
 
-         .. step:: Locate the ``mycnf`` configuration file
+         .. step:: Locate and update the MySQL configuration file
 
-            a. To locate the config file for your MySQL instance run the 
+            a. Run the following SQL query to get the ``server_id`` 
+               value for your MySQL instance:
+
+               .. code-block:: sql
+                  :copyable: true
+
+                  SELECT variable_value 
+                  FROM 
+                  information_schema.global_variables 
+                  WHERE variable_name='server_id';
+
+            #. To locate the config file for your MySQL instance run the 
                following ``mysqld`` command from the terminal:
 
                .. tabs::
@@ -107,21 +118,17 @@ Steps
 
                         mysql --help | findstr cnf
 
-            #. Run the following SQL query to get the ``server_id`` 
-               value for your deployment:
-               
-               .. code-block:: sql
-                  :copyable: true
-
-                  SELECT variable_value 
-                  FROM 
-                  information_schema.global_variables 
-                  WHERE variable_name='server_id';
-
             #. Under the ``mysqld`` section of your mySQL configuration 
-               file add the following lines, replace the ``XXXXX`` value 
+               file add the following lines. Replace the ``XXXXX`` value 
                with the ``server_id`` from the previous query:
 
+            .. note::
+
+               If your running MySQL on AWS RDS, you must enable 
+               automated backups for binary logging. If automated 
+               backups are not enabled, ``binlog`` is disabled even
+               if setting the values in the configuration file.
+               
                .. tab:: MySql 8.x
                   :tabid: mysql-8x
 
@@ -145,6 +152,7 @@ Steps
                      binlog_format               = ROW
                      binlog_row_image            = FULL
                      expire_log_days = 10 
+
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -18,7 +18,7 @@ Database Administrator (DBA) review the commands in this script and
 perform their execution on the database server. The 
 MySQL Server configurations depend on the type of sync job:
 
-.. include:: /includes/fact-short-sync-job-desc.rst
+.. include:: /includes/pfact-short-sync-job-desc.rst
 
 For details on supported versions of MySQL, see 
 :ref:`supported-databases`.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -23,14 +23,6 @@ MySQL Server configuration depends on the type of sync job:
 For details on supported versions of MySQL, see 
 :ref:`supported-databases`.
 
-About this Task
----------------
-
-Connecting Relational Migrator to MySQL 
-requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
-to be enabled on your MySQL instance. The binary log (Binlog) records all 
-operations in the order they are committed to the database. 
-
 Steps
 -----
 
@@ -40,72 +32,19 @@ Steps
    .. tab:: Snapshot Jobs
       :tabid: enable-snapshot-jobs
 
-      For snapshot jobs against SQL Server, you must enable 
-      CDC at the database level. 
-
       .. procedure::
          :style: normal
 
-         .. step:: (Optional) Set up user permissions
-
-            Relational Migrator generates SQL scripts that can 
-            be executed to enable 
-            ``Binlog`` for the source MySQL database. The 
-            following code creates a new MySQL service account 
-            for Relational Migrator to connect to the MySQL 
-            instance. 
-
-            Create a service account:
-
-            .. code-block:: sql
-               :copyable: true
-
-               CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
-
-            Grant the required permissions to the service account:
-
-            .. code-block:: sql
-               :copyable: true
-               
-               GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
-
-            Apply the user privilege changes:
-
-            .. code-block:: sql
-               :copyable: true
-
-               FLUSH PRIVILEGES; 
-
-         .. step:: Manually verify Binlog is enabled
-
-               Relational Migrator automatically checks this setting for 
-               you. To manually check the if the ``Binlog`` option is 
-               enabled, use the queries below for your version of MySQL:
-
-               .. tabs::
-
-                  .. tab:: MySql 8.x
-                     :tabid: mysql-8x
-
-                     .. code-block:: sql
-                        :copyable: true
-
-                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-
-                        FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
-
-                  .. tab:: MySql 5.x
-                     :tabid: mysql-5x
-
-                     .. code-block:: sql
-                        :copyable: true
-
-                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-
-                        FROM information_schema.global_variables WHERE variable_name='log_bin';
+         .. include:: /includes/fact-my-sql-setup-user-permission-step.rst
 
    .. tab:: Continuous Jobs
       :tabid: enable-continuous-jobs
+
+         Running continuous jobs on Relational Migrator 
+         requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
+         to be enabled on your MySQL instance. The binary log (Binlog) 
+         records all operations in the order they are committed to the 
+         database. 
 
       .. procedure::
          :style: normal
@@ -140,6 +79,7 @@ Steps
 
          .. step:: Manually verify Binlog is enabled
 
+               
                Relational Migrator automatically checks this setting for 
                you. To manually check the if the ``Binlog`` option is 
                enabled, use the queries below for your version of MySQL:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -146,7 +146,7 @@ Steps
                         binlog_format               = ROW
                         binlog_row_image            = FULL
                         expire_log_days = 10 
-
+            
 Learn More
 ----------
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -89,21 +89,23 @@ Steps
             a. To locate the config file for your MySQL instance run the 
                following ``mysqld`` command from the terminal:
 
-               .. tab:: MacOS / Linux
-                  :tabid: macos-linux
+               .. tabs::
 
-                  .. code-block:: 
-                     :copyable: true
+                  .. tab:: MacOS / Linux
+                     :tabid: macos-linux
 
-                     mysql --help | grep cnf
+                     .. code-block:: 
+                        :copyable: true
 
-               .. tab:: Windows
-                  :tabid: windows
+                        mysql --help | grep cnf
 
-                  .. code-block:: 
-                     :copyable: true
+                  .. tab:: Windows
+                     :tabid: windows
 
-                     mysql --help | findstr cnf
+                     .. code-block:: 
+                        :copyable: true
+
+                        mysql --help | findstr cnf
 
             #. Run the following SQL query to get the ``server_id`` 
                value for your deployment:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -123,13 +123,6 @@ Steps
                file add the following lines. Replace the ``XXXXX`` value 
                with the ``server_id`` from the previous query:
 
-               .. note::
-
-                  If your running MySQL on AWS RDS, you must enable 
-                  automated backups for binary logging. If automated 
-                  backups are not enabled, ``binlog`` is disabled even
-                  if setting the values in the configuration file.
-
                .. tabs::
 
                   .. tab:: MySql 8.x
@@ -155,6 +148,13 @@ Steps
                         binlog_format = ROW
                         binlog_row_image = FULL
                         expire_log_days = 10 
+
+               .. note::
+
+                  If your running MySQL on AWS RDS, you must enable 
+                  automated backups for binary logging. If automated 
+                  backups are not enabled, ``binlog`` is disabled even
+                  if setting the values in the configuration file.
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -129,30 +129,32 @@ Steps
                   automated backups for binary logging. If automated 
                   backups are not enabled, ``binlog`` is disabled even
                   if setting the values in the configuration file.
-                  
-               .. tab:: MySql 8.x
-                  :tabid: mysql-8x
 
-                  .. code-block::
-                     :copyable: true
+               .. tabs::
 
-                     server-id         = XXXXX
-                     log_bin                     = mysql-bin
-                     binlog_format               = ROW
-                     binlog_row_image            = FULL
-                     binlog_expire_logs_seconds  = 864000
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
 
-               .. tab:: MySql 5.x
-                  :tabid: mysql-5x
+                     .. code-block::
+                        :copyable: true
 
-                  .. code-block:: 
-                     :copyable: true
+                        server-id         = XXXXX
+                        log_bin                     = mysql-bin
+                        binlog_format               = ROW
+                        binlog_row_image            = FULL
+                        binlog_expire_logs_seconds  = 864000
 
-                     server-id         = XXXXX
-                     log_bin                     = mysql-bin
-                     binlog_format               = ROW
-                     binlog_row_image            = FULL
-                     expire_log_days = 10 
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
+
+                     .. code-block:: 
+                        :copyable: true
+
+                        server-id         = XXXXX
+                        log_bin                     = mysql-bin
+                        binlog_format               = ROW
+                        binlog_row_image            = FULL
+                        expire_log_days = 10 
 
 
 Learn More

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -46,14 +46,63 @@ Steps
       .. procedure::
          :style: normal
 
-         .. step:: Configure CDC at the Database Level
+         .. step:: (Optional) Set up user permissions
 
-          Enabling CDC at the database-level CDC generates a small 
-          number of system tables in the database, leaving user tables 
-          unchanged, and does not add any performance overhead. Enabling
-          CDC alone does not result in changes being captured.
+            Relational Migrator generates SQL scripts that can 
+            be executed to enable 
+            ``Binlog`` for the source MySQL database. The 
+            following code creates a new MySQL service account 
+            for Relational Migrator to connect to the MySQL 
+            instance. 
 
-            .. include:: /includes/fact-enable-cdc-database.rst
+            Create a service account:
+
+            .. code-block:: sql
+               :copyable: true
+
+               CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+
+            Grant the required permissions to the service account:
+
+            .. code-block:: sql
+               :copyable: true
+               
+               GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+
+            Apply the user privilege changes:
+
+            .. code-block:: sql
+               :copyable: true
+
+               FLUSH PRIVILEGES; 
+
+         .. step:: Manually verify Binlog is enabled
+
+               Relational Migrator automatically checks this setting for 
+               you. To manually check the if the ``Binlog`` option is 
+               enabled, use the queries below for your version of MySQL:
+
+               .. tabs::
+
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
+
+                     .. code-block:: sql
+                        :copyable: true
+
+                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                        FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
+
+                     .. code-block:: sql
+                        :copyable: true
+
+                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                        FROM information_schema.global_variables WHERE variable_name='log_bin';
 
    .. tab:: Continuous Jobs
       :tabid: enable-continuous-jobs

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -10,4 +10,88 @@ MySQL Migration Prerequisites
    :depth: 1
    :class: singlecol
 
-MySQL.
+To run sync jobs from a MySQL source database, the database may require 
+some configuration changes. If Relational Migrator determines the 
+database needs configuration changes, it automatically generates a 
+SQL script with the required changes. It is recommended to have a 
+Database Administrator (DBA) review the commands in this script and 
+perform their execution on the database server. This topic 
+provides more details on the required configuration steps.
+
+.. include:: /includes/fact-short-sync-job-desc.rst
+
+For details on supported versions of MySQL, see 
+:ref:`supported-databases`.
+
+About this Task
+---------------
+
+
+Steps
+-----
+
+Connecting Relational Migrator to MySQL 
+requires the ``binary log feature`` enabed on your MySQL instance. 
+The binary log (Binlog) records all operations in the order
+they are committed to the database. Relational Migrator 
+supports two types of sync jobs:
+
+
+User Permissions & Job Setup 
+
+.. procedure::
+   :style: normal
+
+   .. step:: User Permissions & Job Setup 
+
+      The tool generates SQL that can be executed to enable Binlog for 
+      the source MySQL database, and optionally create a new MySQL 
+      account for the migrator tool. 
+      Reference SQL for Binlog and account creation below:
+
+      .. code-block:: sql
+         :copyable: true
+
+         CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+
+      .. code-block:: sql
+         :copyable: true
+         
+         GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+
+      .. code-block:: sql
+         :copyable: true
+
+         FLUSH PRIVILEGES; 
+
+   .. step:: Manually Verify Binlog Is Enabled
+
+         Note that the tool will automatically check this setting for you. 
+         To manually verify:
+
+         To manually check whether the log-bin option is already enabled:
+
+         .. code-block:: sql
+            :copyable: true
+
+            // for MySql 5.x
+
+            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+            FROM information_schema.global_variables WHERE variable_name='log_bin';
+
+         .. code-block:: sql
+            :copyable: true
+
+            // for MySql 8.x
+
+            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+            FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+
+Learn More
+----------
+
+Relational Migrator relies on the open-source Debezium connector to 
+capture row-level changes. For more details, see
+`Debezium SQL Server <https://debezium.io/documentation/reference/stable/connectors/mysql.html >`__.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -107,4 +107,4 @@ Learn More
 
 Relational Migrator relies on the open-source Debezium connector to 
 capture row-level changes. For more details, see
-`Debezium SQL Server <https://debezium.io/documentation/reference/stable/connectors/mysql.html >`__.
+`Debezium SQL Server <https://debezium.io/documentation/reference/stable/connectors/mysql.html>`__.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -89,29 +89,29 @@ Steps
             a. Run the following SQL query to get the ``server_id`` 
                value for your MySQL instance:
 
-                  .. tabs::
+               .. tabs::
 
-                     .. tab:: MySql 8.x
-                        :tabid: mysql-8x
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
 
-                        .. code-block:: sql
-                           :copyable: true
+                     .. code-block:: sql
+                        :copyable: true
 
-                           SELECT variable_value 
-                           FROM 
-                           performance_schema.global_variables 
-                           WHERE variable_name='server_id';
+                        SELECT variable_value 
+                        FROM 
+                        performance_schema.global_variables 
+                        WHERE variable_name='server_id';
 
-                     .. tab:: MySql 5.x
-                        :tabid: mysql-5x
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
 
-                        .. code-block:: sql
-                           :copyable: true
+                     .. code-block:: sql
+                        :copyable: true
 
-                           SELECT variable_value 
-                           FROM 
-                           information_schema.global_variables 
-                           WHERE variable_name='server_id';
+                        SELECT variable_value 
+                        FROM 
+                        information_schema.global_variables 
+                        WHERE variable_name='server_id';
 
             #. Locate the config file for your MySQL instance by running 
                the following ``mysqld`` command in your terminal:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -57,65 +57,65 @@ Steps
 
    .. tab:: Continuous Jobs
       :tabid: enable-continuous-jobs
-      
-   .. procedure::
-      :style: normal
 
-      .. step:: (Optional) Set up user permissions
+      .. procedure::
+         :style: normal
 
-         Relational Migrator generates SQL scripts that can be executed to enable 
-         ``Binlog`` for the source MySQL database. The following 
-         code creates a new MySQL service account for Relational Migrator 
-         to connect to the MySQL instance. 
+         .. step:: (Optional) Set up user permissions
 
-         Create a service account:
+            Relational Migrator generates SQL scripts that can be executed to enable 
+            ``Binlog`` for the source MySQL database. The following 
+            code creates a new MySQL service account for Relational Migrator 
+            to connect to the MySQL instance. 
 
-         .. code-block:: sql
-            :copyable: true
+            Create a service account:
 
-            CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+            .. code-block:: sql
+               :copyable: true
 
-         Grant the required permissions to the service account:
+               CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
 
-         .. code-block:: sql
-            :copyable: true
-            
-            GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+            Grant the required permissions to the service account:
 
-         Apply the user privilege changes:
+            .. code-block:: sql
+               :copyable: true
+               
+               GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
 
-         .. code-block:: sql
-            :copyable: true
+            Apply the user privilege changes:
 
-            FLUSH PRIVILEGES; 
+            .. code-block:: sql
+               :copyable: true
 
-      .. step:: Manually verify Binlog is enabled
+               FLUSH PRIVILEGES; 
 
-            Relational Migrator automatically checks this setting for 
-            you. To manually check the if the ``Binlog`` option is 
-            enabled, use the queries below for your version of MySQL:
+         .. step:: Manually verify Binlog is enabled
 
-            .. tabs::
+               Relational Migrator automatically checks this setting for 
+               you. To manually check the if the ``Binlog`` option is 
+               enabled, use the queries below for your version of MySQL:
 
-               .. tab:: MySql 8.x
-                  :tabid: mysql-8x
+               .. tabs::
 
-                  .. code-block:: sql
-                     :copyable: true
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
 
-                     SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+                     .. code-block:: sql
+                        :copyable: true
 
-                     FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 
-               .. tab:: MySql 5.x
-                  :tabid: mysql-5x
+                        FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
 
-                  .. code-block:: sql
-                     :copyable: true
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
 
-                     SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+                     .. code-block:: sql
+                        :copyable: true
 
-                     FROM information_schema.global_variables WHERE variable_name='log_bin';
+                        SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                        FROM information_schema.global_variables WHERE variable_name='log_bin';
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -16,7 +16,7 @@ database needs configuration changes, it automatically generates a
 SQL script with the required changes. It is recommended to have a 
 Database Administrator (DBA) review the commands in this script and 
 perform their execution on the database server. This topic 
-provides more details on the required configuration steps.
+MySQL Server configuration depends on the type of sync job:
 
 .. include:: /includes/fact-short-sync-job-desc.rst
 
@@ -28,7 +28,7 @@ About this Task
 
 Connecting Relational Migrator to MySQL 
 requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
-enabed on your MySQL instance. The binary log (Binlog) records all 
+to be enabled on your MySQL instance. The binary log (Binlog) records all 
 operations in the order they are committed to the database. 
 
 Steps
@@ -37,9 +37,9 @@ Steps
 .. procedure::
    :style: normal
 
-   .. step:: (Optional) User permissions setup 
+   .. step:: (Optional) Set up user permissions
 
-      Relational Migrator generates SQL that can be executed to enable 
+      Relational Migrator generates SQL scripts that can be executed to enable 
       ``Binlog`` for the source MySQL database. The following 
       code creates a new MySQL service account for Relational Migrator 
       to connect to the MySQL instance. 
@@ -67,8 +67,8 @@ Steps
 
    .. step:: Manually verify Binlog is enabled
 
-         Relational Migrator automaticaly checks this setting for 
-         you. To manually check the if the Binlog`` option is 
+         Relational Migrator automatically checks this setting for 
+         you. To manually check the if the ``Binlog`` option is 
          enabled, use the queries below for your version of MySQL:
 
          .. tabs::

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-mysql:
 
-================================================
-Configure Data Migration Prerequisites for MySQL
-================================================
+===========================================
+Configure Migration Prerequisites for MySQL
+===========================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -42,22 +42,28 @@ User Permissions & Job Setup
 .. procedure::
    :style: normal
 
-   .. step:: User Permissions & Job Setup 
+   .. step:: (Optional) User permissions and job setup 
 
-      The tool generates SQL that can be executed to enable Binlog for 
-      the source MySQL database, and optionally create a new MySQL 
-      account for the migrator tool. 
-      Reference SQL for Binlog and account creation below:
+      Relational Migrator generates SQL that can be executed to enable 
+      ``Binlog`` for the source MySQL database. The following optional 
+      code creates a new MySQL account for Relational Migrator to connect
+      to the MySQL instance. 
+
+      Create a service account:
 
       .. code-block:: sql
          :copyable: true
 
          CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
 
+      Grant the required permissions to the service account:
+
       .. code-block:: sql
          :copyable: true
          
          GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+
+      Apply the user privilege changes:
 
       .. code-block:: sql
          :copyable: true
@@ -66,28 +72,35 @@ User Permissions & Job Setup
 
    .. step:: Manually Verify Binlog Is Enabled
 
-         Note that the tool will automatically check this setting for you. 
-         To manually verify:
+         To manually check the if ``log-bin`` option is already 
+         enabled use the code below for your version of MySQL:
 
-         To manually check whether the log-bin option is already enabled:
+         .. note:: 
+            
+            Relational Migrator automaticaly checks this setting for 
+            you. 
 
-         .. code-block:: sql
-            :copyable: true
+         .. tabs::
 
-            // for MySql 5.x
+            .. tab:: MySql 5.x
+               :tabid: mysql-5x
 
-            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+               .. code-block:: sql
+                  :copyable: true
 
-            FROM information_schema.global_variables WHERE variable_name='log_bin';
+                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 
-         .. code-block:: sql
-            :copyable: true
+                  FROM information_schema.global_variables WHERE variable_name='log_bin';
 
-            // for MySql 8.x
+            .. tab:: MySql 8.x
+               :tabid: mysql-8x
 
-            SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+               .. code-block:: sql
+                  :copyable: true
 
-            FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                  FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -68,8 +68,8 @@ Steps
    .. step:: Manually Verify Binlog Is Enabled
 
          Relational Migrator automaticaly checks this setting for 
-         you. To manually check the if ``log-bin`` option is already 
-         enabled use the code below for your version of MySQL:
+         you. To manually check the if ``Binlog`` option is already 
+         enabled use the queries below for your version of MySQL:
 
          .. tabs::
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -90,20 +90,20 @@ Steps
                following ``mysqld`` command from the terminal:
 
                .. tab:: MacOS / Linux
-                     :tabid: macos-linux
+                  :tabid: macos-linux
 
-                     .. code-block:: 
-                        :copyable: true
+                  .. code-block:: 
+                     :copyable: true
 
-                        mysql --help | grep cnf
+                     mysql --help | grep cnf
 
                .. tab:: Windows
-                     :tabid: windows
+                  :tabid: windows
 
-                     .. code-block:: 
-                        :copyable: true
+                  .. code-block:: 
+                     :copyable: true
 
-                        mysql --help | findstr cnf
+                     mysql --help | findstr cnf
 
             #. Run the following SQL query to get the ``server_id`` 
                value for your deployment:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-mysql:
 
-=============================
-MySQL Migration Prerequisites
-=============================
+================================================
+Configure Data Migration Prerequisites for MySQL
+================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -77,16 +77,6 @@ Steps
 
          .. tabs::
 
-            .. tab:: MySql 5.x
-               :tabid: mysql-5x
-
-               .. code-block:: sql
-                  :copyable: true
-
-                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
-
-                  FROM information_schema.global_variables WHERE variable_name='log_bin';
-
             .. tab:: MySql 8.x
                :tabid: mysql-8x
 
@@ -96,6 +86,16 @@ Steps
                   SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
 
                   FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+
+            .. tab:: MySql 5.x
+               :tabid: mysql-5x
+
+               .. code-block:: sql
+                  :copyable: true
+
+                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                  FROM information_schema.global_variables WHERE variable_name='log_bin';
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-mysql:
 
 =============================
-MySQL Migration Prerequisites
+Configure MySQL for Sync Jobs
 =============================
 
 .. contents:: On this page
@@ -167,7 +167,7 @@ Steps
 
                .. note::
 
-                  If you're running MySQL on AWS RDS, you must enable 
+                  If your running MySQL on AWS RDS, you must enable 
                   automated backups for binary logging. If automated 
                   backups are not enabled, ``Binlog`` is disabled even
                   if setting the values in the configuration file.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -89,13 +89,29 @@ Steps
             a. Run the following SQL query to get the ``server_id`` 
                value for your MySQL instance:
 
-               .. code-block:: sql
-                  :copyable: true
+               .. tabs::
 
-                  SELECT variable_value 
-                  FROM 
-                  information_schema.global_variables 
-                  WHERE variable_name='server_id';
+                  .. tab:: MySql 8.x
+                     :tabid: mysql-8x
+
+                     .. code-block:: sql
+                        :copyable: true
+
+                        SELECT variable_value 
+                        FROM 
+                        performance_schema.global_variables 
+                        WHERE variable_name='server_id';
+
+                  .. tab:: MySql 5.x
+                     :tabid: mysql-5x
+
+                     .. code-block:: sql
+                        :copyable: true
+
+                        SELECT variable_value 
+                        FROM 
+                        information_schema.global_variables 
+                        WHERE variable_name='server_id';
 
             #. To locate the config file for your MySQL instance run the 
                following ``mysqld`` command from the terminal:
@@ -118,10 +134,10 @@ Steps
 
                         mysql --help | grep cnf
 
-
-            #. Under the ``mysqld`` section of your mySQL configuration 
-               file add the following lines. Replace the ``XXXXX`` value 
-               with the ``server_id`` from the previous query:
+            #. Under the ``[mysqld] `` section of your MySQL 
+               configuration file add the following lines. Replace 
+               the ``XXXXX`` value with the ``server_id`` from the 
+               previous query:
 
                .. tabs::
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -26,18 +26,13 @@ For details on supported versions of MySQL, see
 About this Task
 ---------------
 
+Connecting Relational Migrator to MySQL 
+requires the `binary log <https://dev.mysql.com/doc/refman/8.0/en/binary-log.html>`__ 
+enabed on your MySQL instance. The binary log (Binlog) records all 
+operations in the order they are committed to the database. 
 
 Steps
 -----
-
-Connecting Relational Migrator to MySQL 
-requires the ``binary log feature`` enabed on your MySQL instance. 
-The binary log (Binlog) records all operations in the order
-they are committed to the database. Relational Migrator 
-supports two types of sync jobs:
-
-
-User Permissions & Job Setup 
 
 .. procedure::
    :style: normal

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -65,11 +65,11 @@ Steps
 
          FLUSH PRIVILEGES; 
 
-   .. step:: Manually Verify Binlog Is Enabled
+   .. step:: Manually verify Binlog is enabled
 
          Relational Migrator automaticaly checks this setting for 
-         you. To manually check the if ``Binlog`` option is already 
-         enabled use the queries below for your version of MySQL:
+         you. To manually check the if the Binlog`` option is 
+         enabled, use the queries below for your version of MySQL:
 
          .. tabs::
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -49,33 +49,7 @@ Steps
       .. procedure::
          :style: normal
 
-         .. step:: (Optional) Set up user permissions
-
-            Relational Migrator generates SQL scripts that can be executed to enable 
-            ``Binlog`` for the source MySQL database. The following 
-            code creates a new MySQL service account for Relational Migrator 
-            to connect to the MySQL instance. 
-
-            Create a service account:
-
-            .. code-block:: sql
-               :copyable: true
-
-               CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
-
-            Grant the required permissions to the service account:
-
-            .. code-block:: sql
-               :copyable: true
-               
-               GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
-
-            Apply the user privilege changes:
-
-            .. code-block:: sql
-               :copyable: true
-
-               FLUSH PRIVILEGES; 
+         .. include:: /includes/fact-my-sql-setup-user-permission-step.rst
 
          .. step:: Manually verify Binlog is enabled
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -98,4 +98,4 @@ Learn More
 
 Relational Migrator relies on the open-source Debezium connector to 
 capture row-level changes. For more details, see
-`Debezium SQL Server <https://debezium.io/documentation/reference/stable/connectors/mysql.html>`__.
+`Debezium MySQL <https://debezium.io/documentation/reference/stable/connectors/mysql.html>`__.

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -23,16 +23,6 @@ MySQL Server configurations depend on the type of sync job:
 For details on supported versions of MySQL, see 
 :ref:`supported-databases`.
 
-
-About this Task
----------------
-
-If your running MySQL on AWS RDS, you must 
-`enable automated backups 
-<https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html>`__ . 
-If automated backups are not enabled, ``binlog`` is 
-disabled even if setting the values in the configuration file.
-
 Steps
 -----
 
@@ -179,7 +169,7 @@ Steps
 
                   If your running MySQL on AWS RDS, you must enable 
                   automated backups for binary logging. If automated 
-                  backups are not enabled, ``binlog`` is disabled even
+                  backups are not enabled, ``Binlog`` is disabled even
                   if setting the values in the configuration file.
 
 Learn More

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -113,8 +113,8 @@ Steps
                         information_schema.global_variables 
                         WHERE variable_name='server_id';
 
-            #. To locate the config file for your MySQL instance run the 
-               following ``mysqld`` command from the terminal:
+            #. Locate the config file for your MySQL instance by running 
+               the following ``mysqld`` command in your terminal:
 
                .. tabs::
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -23,6 +23,16 @@ MySQL Server configurations depend on the type of sync job:
 For details on supported versions of MySQL, see 
 :ref:`supported-databases`.
 
+
+About this Task
+---------------
+
+If your running MySQL on AWS RDS, you must 
+`enable automated backups 
+<https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html>`__ . 
+If automated backups are not enabled, ``binlog`` is 
+disabled even if setting the values in the configuration file.
+
 Steps
 -----
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -138,11 +138,11 @@ Steps
                      .. code-block::
                         :copyable: true
 
-                        server-id         = XXXXX
-                        log_bin                     = mysql-bin
-                        binlog_format               = ROW
-                        binlog_row_image            = FULL
-                        binlog_expire_logs_seconds  = 864000
+                        server-id = XXXXX
+                        log_bin = mysql-bin
+                        binlog_format = ROW
+                        binlog_row_image = FULL
+                        binlog_expire_logs_seconds = 864000
 
                   .. tab:: MySql 5.x
                      :tabid: mysql-5x
@@ -150,12 +150,11 @@ Steps
                      .. code-block:: 
                         :copyable: true
 
-                        server-id         = XXXXX
-                        log_bin                     = mysql-bin
-                        binlog_format               = ROW
-                        binlog_row_image            = FULL
+                        server-id = XXXXX
+                        log_bin = mysql-bin
+                        binlog_format = ROW
+                        binlog_row_image = FULL
                         expire_log_days = 10 
-
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -134,7 +134,7 @@ Steps
 
                         mysql --help | grep cnf
 
-            #. Under the ``[mysqld] `` section of your MySQL 
+            #. Under the ``[mysqld]`` section of your MySQL 
                configuration file add the following lines. Replace 
                the ``XXXXX`` value with the ``server_id`` from the 
                previous query:

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -67,13 +67,9 @@ Steps
 
    .. step:: Manually Verify Binlog Is Enabled
 
-         To manually check the if ``log-bin`` option is already 
+         Relational Migrator automaticaly checks this setting for 
+         you. To manually check the if ``log-bin`` option is already 
          enabled use the code below for your version of MySQL:
-
-         .. note:: 
-            
-            Relational Migrator automaticaly checks this setting for 
-            you. 
 
          .. tabs::
 

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -34,64 +34,88 @@ operations in the order they are committed to the database.
 Steps
 -----
 
-.. procedure::
-   :style: normal
 
-   .. step:: (Optional) Set up user permissions
+.. tabs::
 
-      Relational Migrator generates SQL scripts that can be executed to enable 
-      ``Binlog`` for the source MySQL database. The following 
-      code creates a new MySQL service account for Relational Migrator 
-      to connect to the MySQL instance. 
+   .. tab:: Snapshot Jobs
+      :tabid: enable-snapshot-jobs
 
-      Create a service account:
+      For snapshot jobs against SQL Server, you must enable 
+      CDC at the database level. 
 
-      .. code-block:: sql
-         :copyable: true
+      .. procedure::
+         :style: normal
 
-         CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+         .. step:: Configure CDC at the Database Level
 
-      Grant the required permissions to the service account:
+          Enabling CDC at the database-level CDC generates a small 
+          number of system tables in the database, leaving user tables 
+          unchanged, and does not add any performance overhead. Enabling
+          CDC alone does not result in changes being captured.
 
-      .. code-block:: sql
-         :copyable: true
-         
-         GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
+            .. include:: /includes/fact-enable-cdc-database.rst
 
-      Apply the user privilege changes:
+   .. tab:: Continuous Jobs
+      :tabid: enable-continuous-jobs
+      
+   .. procedure::
+      :style: normal
 
-      .. code-block:: sql
-         :copyable: true
+      .. step:: (Optional) Set up user permissions
 
-         FLUSH PRIVILEGES; 
+         Relational Migrator generates SQL scripts that can be executed to enable 
+         ``Binlog`` for the source MySQL database. The following 
+         code creates a new MySQL service account for Relational Migrator 
+         to connect to the MySQL instance. 
 
-   .. step:: Manually verify Binlog is enabled
+         Create a service account:
 
-         Relational Migrator automatically checks this setting for 
-         you. To manually check the if the ``Binlog`` option is 
-         enabled, use the queries below for your version of MySQL:
+         .. code-block:: sql
+            :copyable: true
 
-         .. tabs::
+            CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
 
-            .. tab:: MySql 8.x
-               :tabid: mysql-8x
+         Grant the required permissions to the service account:
 
-               .. code-block:: sql
-                  :copyable: true
+         .. code-block:: sql
+            :copyable: true
+            
+            GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
 
-                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+         Apply the user privilege changes:
 
-                  FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+         .. code-block:: sql
+            :copyable: true
 
-            .. tab:: MySql 5.x
-               :tabid: mysql-5x
+            FLUSH PRIVILEGES; 
 
-               .. code-block:: sql
-                  :copyable: true
+      .. step:: Manually verify Binlog is enabled
 
-                  SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+            Relational Migrator automatically checks this setting for 
+            you. To manually check the if the ``Binlog`` option is 
+            enabled, use the queries below for your version of MySQL:
 
-                  FROM information_schema.global_variables WHERE variable_name='log_bin';
+            .. tabs::
+
+               .. tab:: MySql 8.x
+                  :tabid: mysql-8x
+
+                  .. code-block:: sql
+                     :copyable: true
+
+                     SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                     FROM performance_schema.global_variables WHERE variable_name='log_bin'; 
+
+               .. tab:: MySql 5.x
+                  :tabid: mysql-5x
+
+                  .. code-block:: sql
+                     :copyable: true
+
+                     SELECT variable_value as "BINARY LOGGING STATUS (log-bin) ::"
+
+                     FROM information_schema.global_variables WHERE variable_name='log_bin';
 
 Learn More
 ----------

--- a/source/prerequisites/my-sql.txt
+++ b/source/prerequisites/my-sql.txt
@@ -89,29 +89,29 @@ Steps
             a. Run the following SQL query to get the ``server_id`` 
                value for your MySQL instance:
 
-               .. tabs::
+                  .. tabs::
 
-                  .. tab:: MySql 8.x
-                     :tabid: mysql-8x
+                     .. tab:: MySql 8.x
+                        :tabid: mysql-8x
 
-                     .. code-block:: sql
-                        :copyable: true
+                        .. code-block:: sql
+                           :copyable: true
 
-                        SELECT variable_value 
-                        FROM 
-                        performance_schema.global_variables 
-                        WHERE variable_name='server_id';
+                           SELECT variable_value 
+                           FROM 
+                           performance_schema.global_variables 
+                           WHERE variable_name='server_id';
 
-                  .. tab:: MySql 5.x
-                     :tabid: mysql-5x
+                     .. tab:: MySql 5.x
+                        :tabid: mysql-5x
 
-                     .. code-block:: sql
-                        :copyable: true
+                        .. code-block:: sql
+                           :copyable: true
 
-                        SELECT variable_value 
-                        FROM 
-                        information_schema.global_variables 
-                        WHERE variable_name='server_id';
+                           SELECT variable_value 
+                           FROM 
+                           information_schema.global_variables 
+                           WHERE variable_name='server_id';
 
             #. Locate the config file for your MySQL instance by running 
                the following ``mysqld`` command in your terminal:

--- a/source/prerequisites/oracle.txt
+++ b/source/prerequisites/oracle.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-oracle:
 
-=================================================
-Configure Data Migration Prerequisites for Oracle
-=================================================
+============================================
+Configure Migration Prerequisites for Oracle
+============================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/oracle.txt
+++ b/source/prerequisites/oracle.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-oracle:
 
 ==============================
-Oracle Migration Prerequisites
+Configure Oracle for Sync Jobs
 ==============================
 
 .. contents:: On this page

--- a/source/prerequisites/oracle.txt
+++ b/source/prerequisites/oracle.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-oracle:
 
 ==============================
-Configure Oracle for Sync Jobs
+Oracle Migration Prerequisites
 ==============================
 
 .. contents:: On this page

--- a/source/prerequisites/oracle.txt
+++ b/source/prerequisites/oracle.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-oracle:
 
-==============================
-Oracle Migration Prerequisites
-==============================
+=================================================
+Configure Data Migration Prerequisites for Oracle
+=================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/postgres.txt
+++ b/source/prerequisites/postgres.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-postgres:
 
-=====================================================
-Configure Data Migration Prerequisites for PostgreSQL
-=====================================================
+================================================
+Configure Migration Prerequisites for PostgreSQL
+================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/postgres.txt
+++ b/source/prerequisites/postgres.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-postgres:
 
-==================================
-Configure PostGreSQL for Sync Jobs
-==================================
+================================
+Postgres Migration Prerequisites
+================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/postgres.txt
+++ b/source/prerequisites/postgres.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-postgres:
 
-================================
-Postgres Migration Prerequisites
-================================
+==================================
+Configure PostGreSQL for Sync Jobs
+==================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/postgres.txt
+++ b/source/prerequisites/postgres.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-postgres:
 
-================================
-Postgres Migration Prerequisites
-================================
+=====================================================
+Configure Data Migration Prerequisites for PostgreSQL
+=====================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-sqlserver:
 
-==================================
-SQL Server Migration Prerequisites
-==================================
+=====================================================
+Configure Data Migration Prerequisites for SQL Server
+=====================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-sqlserver:
 
-=====================================================
-Configure Data Migration Prerequisites for SQL Server
-=====================================================
+================================================
+Configure Migration Prerequisites for SQL Server
+================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -21,9 +21,7 @@ perform their execution on the database server. This topic
 provides more details on the required configuration steps. SQL Server 
 configuration depends on the type of sync job: 
 
-- Snapshot sync jobs migrate all the data and then stops.
-- Continuous sync job run a snapshot and then enter a CDC stage to 
-  continuously replicate data changes.
+.. include:: /includes/fact-short-sync-job-desc.rst
 
 About this Task
 ---------------

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-sqlserver:
 
 ==================================
-Configure SQL Server for Sync Jobs
+SQL Server Migration Prerequisites
 ==================================
 
 .. contents:: On this page

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -69,7 +69,7 @@ job configurations.
           unchanged, and does not add any performance overhead. Enabling
           CDC alone does not result in changes being captured.
 
-            .. include:: /includes/fact-enable-cdc-database.rst
+         .. include:: /includes/fact-enable-cdc-database.rst
 
    .. tab:: Continuous Jobs
       :tabid: enable-continuous-jobs

--- a/source/prerequisites/sql-server.txt
+++ b/source/prerequisites/sql-server.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-sqlserver:
 
 ==================================
-SQL Server Migration Prerequisites
+Configure SQL Server for Sync Jobs
 ==================================
 
 .. contents:: On this page

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,0 +1,15 @@
+.. _rm-prereq-mysql:
+
+=============================
+Sybase Migration Prerequisites
+=============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+
+There are no prerequisites requirements to use Relational Migrator with
+Sybase ASE.

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -11,4 +11,4 @@ Sybase Migration Prerequisites
    :class: singlecol
 
 There are no prerequisite requirements to use Relational Migrator with
-Sybase ASE. Sybase only supports snapshot jobs.
+Sybase ASE. Sybase only supports snapshot sync jobs.

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-mysql:
 
 ==============================
-Sybase Migration Prerequisites
+Configure Sybase for Sync Jobs
 ==============================
 
 .. contents:: On this page

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -11,5 +11,5 @@ Sybase Migration Prerequisites
    :class: singlecol
 
 
-There are no prerequisites requirements to use Relational Migrator with
+There are no prerequisite requirements to use Relational Migrator with
 Sybase ASE.

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -10,6 +10,5 @@ Sybase Migration Prerequisites
    :depth: 1
    :class: singlecol
 
-
 There are no prerequisite requirements to use Relational Migrator with
-Sybase ASE.
+Sybase ASE. Sybase only supports snapshot jobs.

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,7 +1,7 @@
 .. _rm-prereq-mysql:
 
 ==============================
-Configure Sybase for Sync Jobs
+Sybase Migration Prerequisites
 ==============================
 
 .. contents:: On this page

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-mysql:
 
-==============================
-Sybase Migration Prerequisites
-==============================
+=================================================
+Configure Data Migration Prerequisites for Sybase
+=================================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-mysql:
 
-=================================================
-Configure Data Migration Prerequisites for Sybase
-=================================================
+============================================
+Configure Migration Prerequisites for Sybase
+============================================
 
 .. contents:: On this page
    :local:

--- a/source/prerequisites/sybase.txt
+++ b/source/prerequisites/sybase.txt
@@ -1,8 +1,8 @@
 .. _rm-prereq-mysql:
 
-=============================
+==============================
 Sybase Migration Prerequisites
-=============================
+==============================
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
## DESCRIPTION

Includes data pre-req requirements for using Relational Migrator with MySQL. Also adding a generic page that states there are no pre-req requirements for Sybase ASE.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-34352/prerequisites/my-sql/

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-34352/prerequisites/sybase/


## JIRA

https://jira.mongodb.org/browse/DOCSP-34352

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c524916b2f17c95a3dfc35

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)