### PR TITLE
DOCSP-36552 -- Update Oracle supported dbs to include 11g

### DIFF
--- a/source/getting-started/supported-databases.txt
+++ b/source/getting-started/supported-databases.txt
@@ -39,7 +39,7 @@ Relational Migrator supports the following source databases:
      - Deployments 
 
    * - Oracle 
-     - 12c and higher
+     - 11g and higher
      - Self hosted, AWS RDS
 
    * - Microsoft SQL Server


### PR DESCRIPTION
## DESCRIPTION
Update Oracle supported dbs to include 11g.

## STAGING
https://preview-mongodbjvincentmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-36552/getting-started/supported-databases/

## JIRA
https://jira.mongodb.org/browse/DOCSP-36552

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660dd2253a5920a291d247a7

## Self-Review Checklist

- [ x] Is this free of any warnings or errors in the RST?
- [x ] Is this free of spelling errors?
- [x ] Is this free of grammatical errors?
- [ x] Is this free of staging / rendering issues?
- [ x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)