### PR TITLE
DOCSP-38507 Fix Atlas Trigger Refs

### DIFF
--- a/source/code-generation/query-converter/convert-triggers.txt
+++ b/source/code-generation/query-converter/convert-triggers.txt
@@ -11,7 +11,7 @@ Convert Triggers
    :class: singlecol
 
 You can import and convert your SQL triggers to 
-:ref:`MongoDB Atlas Triggers <atlas-triggers>` with the query converter. 
+:ref:`MongoDB Atlas Triggers <triggers>` with the query converter. 
 The query converter considers the SQL code and relational schema defined 
 in your project when converting your triggers.
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -24,7 +24,7 @@ New features:
   account. When you sign into Atlas, the process for
   selecting Atlas clusters in a sync job is dynamically populated.
 - Query converter now supports conversion of relational database DML 
-  triggers to :ref:`Atlas Triggers <atlas-triggers>`.
+  triggers to :ref:`Atlas Triggers <triggers>`.
 
 Improvements:
 


### PR DESCRIPTION
## DESCRIPTION

Fixes some refs that were recently moved from the `cloud-docs` repo to the `app-services` repo.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-38507/release-notes/#1.5.0-changelog

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-38507/code-generation/query-converter/convert-triggers/#convert-triggers

## JIRA

https://jira.mongodb.org/browse/DOCSP-38507

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6618021a3a5920a2913c498d

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)