### PR TITLE
DOCSP-35064 Add Sybase Mentions to Corpus

### DIFF
--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -207,7 +207,7 @@ The general form for a Sybase connection string is:
 
 .. code-block::
 
-   jdbc:sybase:Tds:[host]:[port]/[databaseName]
+   jdbc:jtds:sybase://[host]:[port]/[databaseName]
 
 .. note::
 

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -24,6 +24,7 @@ Relational Migrator can connect to the following relational database systems:
 - `Oracle <#oracle>`__
 - `PostgreSQL <#postgresql>`__
 - `SQL Server <#sql-server>`__
+- `Sybase <#sybase>`__
 
 Relational Migrator's connection form contains fields where you can specify a
 username and password for the connection. The form obscures passwords
@@ -198,3 +199,12 @@ the default ``dbo`` schema in all databases.
 
 If you specify the ``databaseName`` property, you can see tables from
 all schemas within the specified database.
+
+Sybase
+------
+
+The general form for a Sybase connection string is:
+
+.. code-block::
+
+   jdbc:sybase:Tds:[host]:[port]/[databaseName]

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -208,3 +208,15 @@ The general form for a Sybase connection string is:
 .. code-block::
 
    jdbc:sybase:Tds:[host]:[port]/[databaseName]
+
+
+.. note::
+
+   https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html
+
+.. note::
+
+   To learn more about Sybase ASE connection strings, see:
+
+   - `Sybase Connection String Docs < https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
+   - `Connectingstrings.com <https://www.connectionstrings.com/sybase-adaptive/>`__.

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -24,7 +24,7 @@ Relational Migrator can connect to the following relational database systems:
 - `Oracle <#oracle>`__
 - `PostgreSQL <#postgresql>`__
 - `SQL Server <#sql-server>`__
-- `Sybase ASE <#sybase>`__
+- `Sybase ASE <#sybase-ASE>`__
 
 Relational Migrator's connection form contains fields where you can specify a
 username and password for the connection. The form obscures passwords
@@ -200,8 +200,8 @@ the default ``dbo`` schema in all databases.
 If you specify the ``databaseName`` property, you can see tables from
 all schemas within the specified database.
 
-Sybase
-------
+Sybase ASE
+----------
 
 The general form for a Sybase ASE connection string is:
 

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -218,5 +218,5 @@ The general form for a Sybase connection string is:
 
    To learn more about Sybase ASE connection strings, see:
 
-   - `Sybase Connection String Docs < https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
+   - `Sybase Connection String Docs <https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
    - `Connectingstrings.com <https://www.connectionstrings.com/sybase-adaptive/>`__.

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -24,7 +24,7 @@ Relational Migrator can connect to the following relational database systems:
 - `Oracle <#oracle>`__
 - `PostgreSQL <#postgresql>`__
 - `SQL Server <#sql-server>`__
-- `Sybase <#sybase>`__
+- `Sybase ASE <#sybase>`__
 
 Relational Migrator's connection form contains fields where you can specify a
 username and password for the connection. The form obscures passwords
@@ -203,7 +203,7 @@ all schemas within the specified database.
 Sybase
 ------
 
-The general form for a Sybase connection string is:
+The general form for a Sybase ASE connection string is:
 
 .. code-block::
 
@@ -213,5 +213,5 @@ The general form for a Sybase connection string is:
 
    To learn more about Sybase ASE connection strings, see:
 
-   - `Sybase Connection String Docs <https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
+   - `Sybase ASE Connection String Docs <https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
    - `Connectingstrings.com <https://www.connectionstrings.com/sybase-adaptive/>`__.

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -214,4 +214,4 @@ The general form for a Sybase ASE connection string is:
    To learn more about Sybase ASE connection strings, see:
 
    - `Sybase ASE Connection String Docs <https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html>`__
-   - `Connectingstrings.com <https://www.connectionstrings.com/sybase-adaptive/>`__.
+   - `Connectingstrings.com <https://www.connectionstrings.com/sybase-adaptive/>`__

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -24,7 +24,7 @@ Relational Migrator can connect to the following relational database systems:
 - `Oracle <#oracle>`__
 - `PostgreSQL <#postgresql>`__
 - `SQL Server <#sql-server>`__
-- `Sybase ASE <#sybase-ASE>`__
+- `Sybase ASE <#sybase-ase>`__
 
 Relational Migrator's connection form contains fields where you can specify a
 username and password for the connection. The form obscures passwords

--- a/source/connection-strings/relational-database-connection-strings.txt
+++ b/source/connection-strings/relational-database-connection-strings.txt
@@ -209,11 +209,6 @@ The general form for a Sybase connection string is:
 
    jdbc:sybase:Tds:[host]:[port]/[databaseName]
 
-
-.. note::
-
-   https://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.infocenter.dc01776.1601/doc/html/san1357754914053.html
-
 .. note::
 
    To learn more about Sybase ASE connection strings, see:

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -71,7 +71,9 @@ Steps
           - Enter a database name, or leave blank to load all databases.
         * - Postgres 
           - Leaving database name blank loads schemas from the default database.
-
+        * - Sybase
+          - Leaving database name blank loads schemas from the default database.
+  
       2e. Enter a username in the :guilabel:`Username` text box. 
 
       2f. Enter a password in the :guilabel:`Password` text box. 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -71,7 +71,7 @@ Steps
           - Enter a database name, or leave blank to load all databases.
         * - Postgres 
           - Leaving database name blank loads schemas from the default database.
-        * - Sybase
+        * - Sybase ASE
           - Leaving database name blank loads schemas from the default database.
   
       2e. Enter a username in the :guilabel:`Username` text box. 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -175,3 +175,4 @@ each database, see the following:
 * `Oracle <https://debezium.io/documentation/reference/stable/connectors/oracle.html#_preparing_the_database>`__
 * `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
 * `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
+

--- a/source/jobs/prerequisites.txt
+++ b/source/jobs/prerequisites.txt
@@ -41,7 +41,7 @@ first sync job:
      - :icon-lg:`Checkmark`
      - :icon-lg:`Checkmark`
 
-   * - :ref:`Sybase <rm-prereq-sybase>`
+   * - :ref:`Sybase ASE <rm-prereq-sybase>`
      - :icon-lg:`Checkmark`
      - 
 

--- a/source/jobs/prerequisites/sybase.txt
+++ b/source/jobs/prerequisites/sybase.txt
@@ -11,4 +11,4 @@ Configure Migration Prerequisites for Sybase
    :class: singlecol
 
 There are no prerequisite requirements to use Relational Migrator with
-Sybase ASE. Sybase only supports snapshot sync jobs.
+Sybase ASE. Sybase ASE only supports snapshot sync jobs.

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -74,7 +74,7 @@ Steps
          * - Postgres
            - Leaving database name blank loads schemas from the default database.
 
-         * - Sybase
+         * - Sybase ASE
            - Leaving database name blank loads schemas from the default database.
 
    d. Enter a user name in the :guilabel:`Username` text box.

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -43,7 +43,7 @@ Steps
    - Oracle
    - PostgreSQL
    - SQL Server
-   - Sybase
+   - Sybase ASE
 
 #. Enter the connection details to create the JDBC URI for your relational database.
 

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -43,6 +43,7 @@ Steps
    - Oracle
    - PostgreSQL
    - SQL Server
+   - Sybase
 
 #. Enter the connection details to create the JDBC URI for your relational database.
 
@@ -71,6 +72,9 @@ Steps
            - Leaving database name blank loads all databases.
 
          * - Postgres
+           - Leaving database name blank loads schemas from the default database.
+
+         * - Sybase
            - Leaving database name blank loads schemas from the default database.
 
    d. Enter a user name in the :guilabel:`Username` text box.

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -103,6 +103,11 @@ to generate DDL files from your relational system.
 
       #. Select :guilabel:`Options` and enable :guilabel:`Include CREATE DATABASE statement`.
 
+   .. tab:: Sybase
+      :tabid: postgresql-ddl
+
+      1. Get Details
+
 Steps
 -----
 

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -106,7 +106,7 @@ to generate DDL files from your relational system.
    .. tab:: Sybase
       :tabid: sybase-ddl
 
-      1. Get Details
+      Importing DDL files with SybaseASE is not supported.
 
 Steps
 -----

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -103,7 +103,7 @@ to generate DDL files from your relational system.
 
       #. Select :guilabel:`Options` and enable :guilabel:`Include CREATE DATABASE statement`.
 
-   .. tab:: Sybase
+   .. tab:: Sybase ASE
       :tabid: sybase-ddl
 
       Importing DDL files with Sybase ASE is not supported.

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -104,7 +104,7 @@ to generate DDL files from your relational system.
       #. Select :guilabel:`Options` and enable :guilabel:`Include CREATE DATABASE statement`.
 
    .. tab:: Sybase
-      :tabid: postgresql-ddl
+      :tabid: sybase-ddl
 
       1. Get Details
 

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -106,7 +106,7 @@ to generate DDL files from your relational system.
    .. tab:: Sybase
       :tabid: sybase-ddl
 
-      Importing DDL files with SybaseASE is not supported.
+      Importing DDL files with Sybase ASE is not supported.
 
 Steps
 -----


### PR DESCRIPTION
## DESCRIPTION

Add Sybase mentions to the connection string page and other supplementary pages where the other RDMS's are mentioned. 

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-35064/connection-strings/relational-database-connection-strings/#sybase

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-35064/jobs/creating-jobs/



## JIRA

https://jira.mongodb.org/browse/DOCSP-35064

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66280179b67dbf804a902a0f

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)