### PR TITLE
DOCSP-34858 Select a cluster option for new sync job

### DIFF
--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -107,8 +107,11 @@ Steps
          .. tab:: Select a cluster
             :tabid: select-atlas-cluster
 
-            On the :guilabel:`Connect Destination DB` form, select an 
-            :guilabel:`Atlas Cluster` from the drop-down. 
+            On the :guilabel:`Connect Destination DB` form, select an :guilabel:`Atlas Cluster` 
+            from the drop-down. Clusters are displayed in a three-level hierarchy: 
+            :guilabel:`Organization` > :guilabel:`Project` > :guilabel:`Cluster`, 
+            organized alphabetically. Only the first 100 clusters you are authorized to 
+            access are shown.
 
             If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
             or :guilabel:`Password` blank, the values from the Atlas cluster's metadata 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -96,10 +96,10 @@ Steps
 
   .. step:: Enter the source MongoDB connection details 
 
-      You can provide the MongoDB connection details by selecting an Atlas
-      cluster or providing a MongoDB connection string (URI). If you are :ref:`logged 
+      To provide the MongoDB connection details, select an Atlas
+      cluster or provide a MongoDB connection string (URI). If you're :ref:`logged 
       in with Atlas <rm-atlas-log-in>`, the default option is to :guilabel:`Select 
-      a cluster`. If you are not logged in with Atlas, the :guilabel:`Select a cluster` 
+      a cluster`. If you aren't logged in with Atlas, the :guilabel:`Select a cluster` 
       option is disabled.
 
       .. tabs::

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -96,16 +96,40 @@ Steps
 
   .. step:: Enter the source MongoDB connection details 
 
-      On the :guilabel:`Connect Destination DB` form, input your 
-      :guilabel:`MongoDB connection string (URI)`.
+      You can provide the MongoDB connection details by selecting an Atlas
+      cluster or providing a MongoDB connection string (URI). If you are :ref:`logged 
+      in with Atlas <rm-atlas-log-in>`, the default option is to select a cluster.
+      If you ar not logged in with Atlas, the :guilabel:`Select a cluster` option is 
+      disabled.
 
-      If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
-      or :guilabel:`Password` blank, the values specified in the URI are used.
+      .. tabs::
 
-      Click :guilabel:`Connect`.
+         .. tab:: Select a cluster
+            :tabid: select-atlas-cluster
+
+            On the :guilabel:`Connect Destination DB` form, select an 
+            :guilabel:`Atlas Cluster` from the drop-down. 
+
+            If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
+            or :guilabel:`Password` blank, the values from the Atlas cluster's metadata 
+            is used.
+
+            Click :guilabel:`Connect`.
+
+         .. tab:: Enter MongoDB URI
+            :tabid: enter-mongodb-uri
+
+
+            On the :guilabel:`Connect Destination DB` form, input your 
+            :guilabel:`MongoDB connection string (URI)`.
+
+            If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
+            or :guilabel:`Password` blank, the values specified in the URI are used.
+
+            Click :guilabel:`Connect`.
 
   .. step:: Select your migration options
-
+   
       On the :guilabel:`Migration Options` form, select your 
       :guilabel:`Migration Options`:
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -98,9 +98,9 @@ Steps
 
       You can provide the MongoDB connection details by selecting an Atlas
       cluster or providing a MongoDB connection string (URI). If you are :ref:`logged 
-      in with Atlas <rm-atlas-log-in>`, the default option is to select a cluster.
-      If you ar not logged in with Atlas, the :guilabel:`Select a cluster` option is 
-      disabled.
+      in with Atlas <rm-atlas-log-in>`, the default option is to :guilabel:`Select 
+      a cluster`. If you are not logged in with Atlas, the :guilabel:`Select a cluster` 
+      option is disabled.
 
       .. tabs::
 
@@ -112,7 +112,7 @@ Steps
 
             If you leave any of the form fields for :guilabel:`Database`, :guilabel:`Username`, 
             or :guilabel:`Password` blank, the values from the Atlas cluster's metadata 
-            is used.
+            are used.
 
             Click :guilabel:`Connect`.
 


### PR DESCRIPTION
## DESCRIPTION
Add the select a cluster option when creating a sync job

## STAGING
https://preview-mongodbjocelynmendez1.gatsbyjs.io/docs-relational-migrator/DOCSP-34858/jobs/creating-jobs/#steps

## JIRA
https://jira.mongodb.org/browse/DOCSP-34858?filter=-1

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=662a7c36b67dbf804a344f63

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)