### PR TITLE
DOCSP-39394 Remove Kafka Private Preview Note

### DIFF
--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -62,4 +62,3 @@ You can perform the following tasks from the **Data Migration** tab.
    /jobs/stopping-jobs
    /jobs/pause-resume-kafka-jobs
    /jobs/data-verification/data-verification
-  

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -28,12 +28,12 @@ followed by a CDC stage that captures database updates in near-real time.
 When you run a continuous sync job, your source and destination database 
 data remain in sync.
 
-.. note:: Private Preview : Kafka Deployment Model
+.. note:: Kafka Deployment Model
 
    The Kafka deployment model of Relational Migrator allows you to run 
    longer-running snapshot or continuous sync jobs with improved resiliency. 
-   This model is currently available in private preview. If you are interested
-   in learning about or testing this model, please contact your MongoDB account team.
+   For more details about the Kafka deployment model, see 
+   :ref:`kafka-intro`.
 
 Get Started
 -----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -62,4 +62,3 @@ You can perform the following tasks from the **Data Migration** tab.
    /jobs/stopping-jobs
    /jobs/pause-resume-kafka-jobs
    /jobs/data-verification/data-verification
-   

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -62,3 +62,4 @@ You can perform the following tasks from the **Data Migration** tab.
    /jobs/stopping-jobs
    /jobs/pause-resume-kafka-jobs
    /jobs/data-verification/data-verification
+  

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -62,3 +62,4 @@ You can perform the following tasks from the **Data Migration** tab.
    /jobs/stopping-jobs
    /jobs/pause-resume-kafka-jobs
    /jobs/data-verification/data-verification
+   


### PR DESCRIPTION
## DESCRIPTION

Changing the private preview note to a pointer to the Kafka docs instead, since Kafka is no longer in private preview.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39394/jobs/sync-jobs/

## JIRA

https://jira.mongodb.org/browse/DOCSP-39394

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=663b6a02b67dbf804a07e0da

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)