### PR TITLE
DOCSP-39174 Add Restart Task Substep to Windows Instructions

### DIFF
--- a/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
+++ b/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
@@ -1,5 +1,5 @@
 .. note::
 
    If you started Relational Migrator before copying the driver files 
-   into the ``Drivers`` directory, you must restart Relational Migrator 
-   to use the MySQL or Oracle drivers.
+   into the ``Drivers`` directory, you must restart the application 
+   in order to use the MySQL or Oracle drivers.

--- a/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
+++ b/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
@@ -1,5 +1,5 @@
 .. note::
 
-   If you started Relational Migrator before copying the files into the 
-   ``Drivers`` directory, you must restart Relational Migrator 
+   If you started Relational Migrator before copying the driver files 
+   into the ``Drivers`` directory, you must restart Relational Migrator 
    to use the MySQL or Oracle drivers.

--- a/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
+++ b/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
@@ -1,5 +1,5 @@
 .. note::
 
-   If you started Relational Migrator before copying the driver files 
+   If you start Relational Migrator before you copy the driver files 
    into the ``Drivers`` directory, you must restart the application 
    to use the MySQL or Oracle drivers.

--- a/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
+++ b/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
@@ -2,4 +2,4 @@
 
    If you started Relational Migrator before copying the driver files 
    into the ``Drivers`` directory, you must restart the application 
-   in order to use the MySQL or Oracle drivers.
+   to use the MySQL or Oracle drivers.

--- a/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
+++ b/source/includes/fact-restart-migrator-oracle-mysql-drivers.rst
@@ -1,0 +1,5 @@
+.. note::
+
+   If you started Relational Migrator before copying the files into the 
+   ``Drivers`` directory, you must restart Relational Migrator 
+   to use the MySQL or Oracle drivers.

--- a/source/installation/install-on-a-local-machine/install-mac.txt
+++ b/source/installation/install-on-a-local-machine/install-mac.txt
@@ -43,6 +43,8 @@ Steps
 
    Double-click the Relational Migrator icon to start the application.
 
+   .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
+
 Next Steps
 ----------
 

--- a/source/installation/install-on-a-local-machine/install-rhel.txt
+++ b/source/installation/install-on-a-local-machine/install-rhel.txt
@@ -57,6 +57,9 @@ Steps
 
       ./mongodb-relational-migrator
 
+   .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
+
+
 Next Steps
 ----------
 

--- a/source/installation/install-on-a-local-machine/install-rhel.txt
+++ b/source/installation/install-on-a-local-machine/install-rhel.txt
@@ -59,7 +59,6 @@ Steps
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 
-
 Next Steps
 ----------
 

--- a/source/installation/install-on-a-local-machine/install-ubuntu.txt
+++ b/source/installation/install-on-a-local-machine/install-ubuntu.txt
@@ -57,6 +57,8 @@ Steps
 
       ./mongodb-relational-migrator
 
+   .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
+
 Next Steps
 ----------
 

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -47,7 +47,7 @@ Steps
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   c. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
+   #. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
       Relational Migrator application.
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -48,7 +48,7 @@ Steps
       default.
 
 #. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
-   Relational Migrator application.
+   application.
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -47,8 +47,8 @@ Steps
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   #. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
-      Relational Migrator application.
+#. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
+   Relational Migrator application.
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -47,7 +47,8 @@ Steps
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   c. Start the Relational Migrator application.
+   c. Double click the ``MongoDB Relational Migrator.exe`` to start the 
+      Relational Migrator application.
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -49,7 +49,7 @@ Steps
 
    c. Start the Relational Migrator application.
 
-      .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
+   .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 
 Next Steps
 ----------

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -40,12 +40,14 @@ Steps
 
       - `Oracle: 21.6.0.0 of ojdbc11.jar from the Oracle 21c <https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html>`_
 
-   b. Copy the driver files to ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``.
+   #. Copy the driver files to ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``.
 
    .. note::
 
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
+
+   #. Restart the Relational Migrator application.
 
 Next Steps
 ----------

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -47,7 +47,9 @@ Steps
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   c. Restart the Relational Migrator application.
+   c. Start the Relational Migrator application.
+
+      .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst
 
 Next Steps
 ----------

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -40,14 +40,14 @@ Steps
 
       - `Oracle: 21.6.0.0 of ojdbc11.jar from the Oracle 21c <https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html>`_
 
-   #. Copy the driver files to ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``.
+   b. Copy the driver files to ``c:\Users\<username>\AppData\Local\MongoDB\Relational Migrator\Data\Drivers``.
 
    .. note::
 
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   #. Restart the Relational Migrator application.
+   c. Restart the Relational Migrator application.
 
 Next Steps
 ----------

--- a/source/installation/install-on-a-local-machine/install-windows.txt
+++ b/source/installation/install-on-a-local-machine/install-windows.txt
@@ -47,7 +47,7 @@ Steps
       Relational Migrator installs the JDBC drivers for SQL Server and PostgreSQL by 
       default.
 
-   c. Double click the ``MongoDB Relational Migrator.exe`` to start the 
+   c. Double-click the ``MongoDB Relational Migrator.exe`` to start the 
       Relational Migrator application.
 
    .. include:: /includes/fact-restart-migrator-oracle-mysql-drivers.rst


### PR DESCRIPTION
## DESCRIPTION

- Adding a restart command to the windows install instructions.
- Added a note to the all install instructions that if you started the application before moving the odbc drivers into the driver folder you must restart.


## STAGING


https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39174/installation/install-on-a-local-machine/install-windows/

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39174/installation/install-on-a-local-machine/install-ubuntu/

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39174/installation/install-on-a-local-machine/install-rhel/

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39174/installation/install-on-a-local-machine/install-mac/

## JIRA

https://jira.mongodb.org/browse/DOCSP-39174

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664cbcd3cf5bec1c29671fac

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)