### PR TITLE
DOCSP-39099 CDC Recoverability Content

### DIFF
--- a/source/includes/fact-cdc-recoverable.rst
+++ b/source/includes/fact-cdc-recoverable.rst
@@ -1,2 +1,2 @@
-A continuous sync job is recoverable within 24-hours of failure. 
+You can recover a continuous sync job within 24-hours of failure. 
 For details, see :ref:`rm-sync-jobs-recoverability`.

--- a/source/includes/fact-cdc-recoverable.rst
+++ b/source/includes/fact-cdc-recoverable.rst
@@ -1,0 +1,2 @@
+A continous sync job is recoverable within 24-hours of failure. 
+For details, see :ref:`rm-sync-jobs-recoverability`.

--- a/source/includes/fact-cdc-recoverable.rst
+++ b/source/includes/fact-cdc-recoverable.rst
@@ -1,2 +1,2 @@
-You can recover a continuous sync job within 24-hours of failure. 
+You can recover a continuous sync job within 24 hours of failure. 
 For details, see :ref:`rm-sync-jobs-recoverability`.

--- a/source/includes/fact-cdc-recoverable.rst
+++ b/source/includes/fact-cdc-recoverable.rst
@@ -1,2 +1,2 @@
-A continous sync job is recoverable within 24-hours of failure. 
+A continuous sync job is recoverable within 24-hours of failure. 
 For details, see :ref:`rm-sync-jobs-recoverability`.

--- a/source/includes/fact-resume-cdc-jobs.rst
+++ b/source/includes/fact-resume-cdc-jobs.rst
@@ -1,0 +1,4 @@
+Relational Migrator automatically restarts Kafka CDC jobs when the 
+application restarts. To restart a continuous sync job that is
+running in embedded mode navigate to the 
+:guilabel:`Data Migration` tab and click :guilabel:`Resume`.

--- a/source/includes/fact-resume-cdc-jobs.rst
+++ b/source/includes/fact-resume-cdc-jobs.rst
@@ -1,4 +1,4 @@
-Relational Migrator automatically restarts Kafka CDC jobs when the 
-application restarts. To restart a continuous sync job that is
-running in embedded mode navigate to the 
+Relational Migrator automatically restarts Kafka CDC jobs if the 
+application restarts or crashes unexpectedly. To restart a 
+continuous sync job that is running in embedded mode navigate to the 
 :guilabel:`Data Migration` tab and click :guilabel:`Resume`.

--- a/source/includes/fact-resume-cdc-jobs.rst
+++ b/source/includes/fact-resume-cdc-jobs.rst
@@ -1,4 +1,0 @@
-Relational Migrator automatically restarts Kafka CDC jobs if the 
-application restarts or crashes unexpectedly. To restart a 
-continuous sync job that failed in embedded mode, navigate to the 
-:guilabel:`Data Migration` tab and click :guilabel:`Resume`.

--- a/source/includes/fact-resume-cdc-jobs.rst
+++ b/source/includes/fact-resume-cdc-jobs.rst
@@ -1,4 +1,4 @@
 Relational Migrator automatically restarts Kafka CDC jobs if the 
 application restarts or crashes unexpectedly. To restart a 
-continuous sync job that is running in embedded mode navigate to the 
+continuous sync job that failed in embedded mode, navigate to the 
 :guilabel:`Data Migration` tab and click :guilabel:`Resume`.

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -25,7 +25,7 @@ About this Task
 .. include:: /includes/fact-kafka-additional-time.rst
 
 - A continous sync job is recoverable within 24-hours of failure. 
-  For details, see :ref:`rm-sync-jobs-recover`.
+  For details, see :ref:`rm-sync-jobs-recoverability`.
 
 Before you Begin
 ----------------

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -24,6 +24,8 @@ About this Task
 
 .. include:: /includes/fact-kafka-additional-time.rst
 
+- .. include:: /includes/fact-resume-cdc-jobs.rst
+
 Before you Begin
 ----------------
 

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -24,8 +24,7 @@ About this Task
 
 .. include:: /includes/fact-kafka-additional-time.rst
 
-- A continous sync job is recoverable within 24-hours of failure. 
-  For details, see :ref:`rm-sync-jobs-recoverability`.
+- .. include:: /includes/fact-cdc-recoverable.rst
 
 Before you Begin
 ----------------

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -24,7 +24,8 @@ About this Task
 
 .. include:: /includes/fact-kafka-additional-time.rst
 
-- .. include:: /includes/fact-resume-cdc-jobs.rst
+- A continous sync job is recoverable within 24-hours of failure. 
+  For details, see :ref:`rm-sync-jobs-recover`.
 
 Before you Begin
 ----------------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -11,36 +11,59 @@ Recover a Sync Job
    :class: singlecol
 
 Relational Migrator can recover continuous (CDC) sync jobs that 
-have failed within a 24-hour period. Procedures 
+have failed within the preceding 24-hour period. Procedures 
 for recovering a CDC sync job depend on if you're using the embedded 
-or Kafka deployment mode.
+or Kafka deployment mode, for details on job types see :ref:`rm-sync-jobs`.
 
-Embedded Mode Recovery
-----------------------
+About this Task
+---------------
 
-For embedded mode recovery, the process to recover
-a sync job is manually triggered. Navigate to the 
-:guilabel:`Data Migration` tab and click 
-:guilabel:`Resume` on the failed CDC sync job. 
+The follow table summarizes the different modes, :
 
-Examples of embedded mode recoverable scenarios include:
+.. list-table::
+   :header-rows: 1
 
-- Unexpected application failure
-- Operating system restarts
+   * - Mode
+     - Description
 
-Kafka Deployment Mode Recovery
-------------------------------
+   * - Embedded Mode
+     - Sync jobs are running on a local machine or unattended server.
 
-For the Kafka deployment mode recovery, the process to recover
-a sync job is automatic. Kafka health checks automatically 
-attempt to resume CDC sync jobs after a failure of 
-individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__
-for up to 24-hours.
+   * - Kafka Mode
+     - Sync jobs are running with Kafka support.
 
-Examples of Kafka CDC sync job recoverable scenarios include:
+Task
+----
 
-- Loss of individual brokers in Kafka cluster
-- Application-level issues resulting in failed health checks
+.. tabs::
+
+   .. tab:: Embedded Mode
+      :tabid: embedded-mode
+
+      .. procedure::
+
+         .. step:: Navigate to the :guilabel:`Data Migration` tab
+
+         .. step:: Click :guilabel:`Resume` on the failed CDC sync job
+
+      Examples of embedded mode recoverable scenarios include:
+
+      - Unexpected application failure
+      - Operating system restarts
+
+   .. tab:: Kafka Deployment
+      :tabid: kafka-deployment
+
+      For the Kafka deployment mode recovery, the process to recover
+      a sync job is automatic. Kafka health checks automatically 
+      attempt to resume CDC sync jobs after a failure of 
+      individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__
+      for up to 24-hours.
+
+      Examples of Kafka CDC sync job recoverable scenarios include:
+
+      - Loss of individual brokers in Kafka cluster
+      - Application-level issues resulting in failed health checks
 
 Learn More
 ----------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -13,7 +13,7 @@ Recover a Sync Job
 Relational Migrator can recover continuous (CDC) sync jobs that 
 have failed within the preceding 24-hour period. Procedures 
 for recovering a CDC sync job depend on if you're using the embedded 
-or Kafka deployment mode, for details on job types see :ref:`rm-sync-jobs`.
+or Kafka deployment mode, for details on each job type see :ref:`rm-sync-jobs`.
 
 About this Task
 ---------------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -57,9 +57,13 @@ for each deployment mode.
       :tabid: embedded-mode
 
       For embedded mode recovery, the process to restart
-      a sync job is manually trigger. Navigate to the 
-      :guilabel:`Data Migration` tab and click 
-      :guilabel:`Resume` on the failed sync job. 
+      a sync job is manually trigger. 
+      
+         .. procedure::
+
+            .. step:: Navigate to the :guilabel:`Data Migration` tab
+            
+            .. step:: Click :guilabel:`Resume` on the failed sync job. 
 
    .. tab:: Kafka Mode
       :tabid: kafka-mode

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -34,7 +34,7 @@ Kafka Deployment Mode Recovery
 For the Kafka deployment mode recovery, the process to restart
 a sync job is automatic. Kafka health checks automatically 
 attempt to resume CDC sync jobs after a failure of 
-individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/#kafka-brokers>`__
+individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__
 for up to 24-hours.
 
 Examples of Kafka CDC sync job recoverable scenarios include:

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -33,7 +33,7 @@ modes:
        a :ref:`unattended server <unattended-server>`.
 
    * - Kafka Mode
-     - Sync jobs are running with :ref:`Kafka support <kafka-intro`.
+     - Sync jobs are running with :ref:`Kafka support <kafka-intro>`.
 
 Task
 ----

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -14,7 +14,7 @@ Relational Migrator can attempt to recover continuous (CDC) sync jobs
 that have failed within the preceding 24-hour period. 
 The procedure for recovering a CDC sync job differs, 
 depending on whether you're using the embedded or Kafka deployment 
-mode, for details on each job type see :ref:`rm-sync-jobs`.
+mode. For details on each job type, see :ref:`rm-sync-jobs`.
 
 About this Task
 ---------------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -11,7 +11,7 @@ Recover a Sync Job
    :class: singlecol
 
 Relational Migrator can recover continuous (CDC) sync jobs that 
-are terminated unexpectedly within a 24-hour period. Procedures 
+are failed within a 24-hour period. Procedures 
 for recovering a CDC sync job depend on if your using the embedded 
 or Kafka deployment mode.
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -12,7 +12,7 @@ Recover a Sync Job
 
 Relational Migrator can recover continuous (CDC) sync jobs that 
 have failed within a 24-hour period. Procedures 
-for recovering a CDC sync job depend on if your using the embedded 
+for recovering a CDC sync job depend on if you're using the embedded 
 or Kafka deployment mode.
 
 Embedded Mode Recovery

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -20,7 +20,7 @@ About this Task
 ---------------
 
 CDC sync job recovery depends on the type of deployment 
-mode your using. The following table summarizes the modes:
+mode your using. The following table summarizes the modes.
 
 .. list-table::
    :header-rows: 1
@@ -35,11 +35,21 @@ mode your using. The following table summarizes the modes:
    * - Kafka Mode
      - Sync jobs that are running with :ref:`Kafka support <kafka-intro>`.
 
+- Examples of embedded mode recoverable scenarios include:
+
+   - Unexpected application failure
+   - Operating system restarts
+
+- Examples of Kafka CDC sync job recoverable scenarios include:
+
+   - Loss of individual brokers in Kafka cluster
+   - Application-level issues resulting in failed health checks
+
 Task
 ----
 
 Click the tab to display the recovery procedure 
-for each deployment mode:
+for each deployment mode.
 
 .. tabs::
 
@@ -51,11 +61,6 @@ for each deployment mode:
       :guilabel:`Data Migration` tab and click 
       :guilabel:`Resume` on the failed sync job. 
 
-      Examples of embedded mode recoverable scenarios include:
-
-      - Unexpected application failure
-      - Operating system restarts
-
    .. tab:: Kafka Mode
       :tabid: kafka-mode
 
@@ -64,11 +69,6 @@ for each deployment mode:
       attempt to resume CDC sync jobs after a failure of 
       individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__
       for up to 24 hours.
-
-      Examples of Kafka CDC sync job recoverable scenarios include:
-
-      - Loss of individual brokers in Kafka cluster
-      - Application-level issues resulting in failed health checks
 
 Learn More
 ----------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -10,9 +10,9 @@ Recover a Sync Job
    :depth: 1
    :class: singlecol
 
-Relational Migrator can recover continuous syncs jobs that are 
-terminated unexpectedly within a 24-hour period. Procedures for 
-recovering your sync job depend on if your using the embedded 
+Relational Migrator can recover continuous (CDC) sync jobs that 
+are terminated unexpectedly within a 24-hour period. Procedures 
+for recovering a CDC sync job depend on if your using the embedded 
 or Kafka deployment mode.
 
 Embedded Mode Recovery
@@ -21,7 +21,7 @@ Embedded Mode Recovery
 For embedded mode recovery, the process to restart
 a sync job is manually trigger. Navigate to the 
 :guilabel:`Data Migration` tab and click 
-:guilabel:`Resume` on the failed sync job. 
+:guilabel:`Resume` on the failed CDC sync job. 
 
 Examples of embedded mode recoverable scenarios include:
 
@@ -34,7 +34,8 @@ Kafka Deployment Mode Recovery
 For the Kafka deployment mode recovery, the process to restart
 a sync job is automatic. Kafka health checks automatically 
 attempt to resume CDC sync jobs after a failure of 
-individual Kafka brokers for up to 24-hours.
+individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/#kafka-brokers>`__
+for up to 24-hours.
 
 Examples of Kafka CDC sync job recoverable scenarios include:
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -18,8 +18,8 @@ or Kafka deployment mode.
 Embedded Mode Recovery
 ----------------------
 
-For embedded mode recovery, the process to restart
-a sync job is manually trigger. Navigate to the 
+For embedded mode recovery, the process to recover
+a sync job is manually triggered. Navigate to the 
 :guilabel:`Data Migration` tab and click 
 :guilabel:`Resume` on the failed CDC sync job. 
 
@@ -31,7 +31,7 @@ Examples of embedded mode recoverable scenarios include:
 Kafka Deployment Mode Recovery
 ------------------------------
 
-For the Kafka deployment mode recovery, the process to restart
+For the Kafka deployment mode recovery, the process to recover
 a sync job is automatic. Kafka health checks automatically 
 attempt to resume CDC sync jobs after a failure of 
 individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -11,9 +11,10 @@ Recover a Sync Job
    :class: singlecol
 
 Relational Migrator can recover continuous (CDC) sync jobs that 
-have failed within the preceding 24-hour period. Procedures 
-for recovering a CDC sync job depend on if you're using the embedded 
-or Kafka deployment mode, for details on each job type see :ref:`rm-sync-jobs`.
+have failed within the preceding 24-hour period. 
+The procedure for recovering a CDC sync job differs, 
+depending on whether you're using the embedded or Kafka deployment 
+mode, for details on each job type see :ref:`rm-sync-jobs`.
 
 About this Task
 ---------------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -56,8 +56,8 @@ for each deployment mode:
       - Unexpected application failure
       - Operating system restarts
 
-   .. tab:: Kafka Deployment
-      :tabid: kafka-deployment
+   .. tab:: Kafka Mode
+      :tabid: kafka-mode
 
       For the Kafka deployment mode recovery, the process to recover
       a sync job is automatic. Kafka health checks automatically 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -18,7 +18,9 @@ or Kafka deployment mode, for details on each job type see :ref:`rm-sync-jobs`.
 About this Task
 ---------------
 
-The follow table summarizes the different modes, :
+CDC sync job recovery depends on the type of deployment 
+mode your using. The following table summarizes the different 
+modes:
 
 .. list-table::
    :header-rows: 1
@@ -27,10 +29,11 @@ The follow table summarizes the different modes, :
      - Description
 
    * - Embedded Mode
-     - Sync jobs are running on a local machine or unattended server.
+     - Sync jobs are running on a :ref:`local machine <local-machine-install>` or 
+       a :ref:`unattended server <unattended-server>`.
 
    * - Kafka Mode
-     - Sync jobs are running with Kafka support.
+     - Sync jobs are running with :ref:`Kafka support <kafka-intro`.
 
 Task
 ----
@@ -40,11 +43,10 @@ Task
    .. tab:: Embedded Mode
       :tabid: embedded-mode
 
-      .. procedure::
-
-         .. step:: Navigate to the :guilabel:`Data Migration` tab
-
-         .. step:: Click :guilabel:`Resume` on the failed CDC sync job
+      For embedded mode recovery, the process to restart
+      a sync job is manually trigger. Navigate to the 
+      :guilabel:`Data Migration` tab and click 
+      :guilabel:`Resume` on the failed sync job. 
 
       Examples of embedded mode recoverable scenarios include:
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -1,4 +1,4 @@
-.. _rm-sync-jobs-recoverability
+.. _rm-sync-jobs-recoverability:
 
 ==================
 Recover a Sync Job

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -11,7 +11,7 @@ Recover a Sync Job
    :class: singlecol
 
 Relational Migrator can recover continuous (CDC) sync jobs that 
-are failed within a 24-hour period. Procedures 
+have failed within a 24-hour period. Procedures 
 for recovering a CDC sync job depend on if your using the embedded 
 or Kafka deployment mode.
 
@@ -42,4 +42,8 @@ Examples of Kafka CDC sync job recoverable scenarios include:
 - Loss of individual brokers in Kafka cluster
 - Application-level issues resulting in failed health check
 
+Learn More
+----------
 
+- :ref:`rm-create-jobs`
+- :ref:`rm-monitor-jobs`

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -19,21 +19,21 @@ mode. For details on each job type, see :ref:`rm-sync-jobs`.
 About this Task
 ---------------
 
-CDC sync job recovery depends on the type of deployment 
-mode your using. The following table summarizes the modes.
+- CDC sync job recovery depends on the type of deployment 
+  mode your using. The following table summarizes the modes.
 
-.. list-table::
-   :header-rows: 1
+  .. list-table::
+     :header-rows: 1
 
-   * - Mode
-     - Description
+     * - Mode
+       - Description
 
-   * - Embedded Mode
-     - Sync jobs that are running on a :ref:`local machine <local-machine-install>` or 
-       a :ref:`unattended server <unattended-server>`.
+     * - Embedded Mode
+       - Sync jobs that are running on a :ref:`local machine <local-machine-install>` or 
+         a :ref:`unattended server <unattended-server>`.
 
-   * - Kafka Mode
-     - Sync jobs that are running with :ref:`Kafka support <kafka-intro>`.
+     * - Kafka Mode
+       - Sync jobs that are running with :ref:`Kafka support <kafka-intro>`.
 
 - Examples of embedded mode recoverable scenarios include:
 
@@ -62,7 +62,7 @@ for each deployment mode.
          .. procedure::
 
             .. step:: Navigate to the :guilabel:`Data Migration` tab
-            
+
             .. step:: Click :guilabel:`Resume` on the failed sync job. 
 
    .. tab:: Kafka Mode

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -40,7 +40,7 @@ for up to 24-hours.
 Examples of Kafka CDC sync job recoverable scenarios include:
 
 - Loss of individual brokers in Kafka cluster
-- Application-level issues resulting in failed health check
+- Application-level issues resulting in failed health checks
 
 Learn More
 ----------

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -42,7 +42,7 @@ About this Task
 
 - Examples of Kafka CDC sync job recoverable scenarios include:
 
-   - Loss of individual brokers in Kafka cluster
+   - Loss of individual `brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__ in Kafka cluster
    - Application-level issues resulting in failed health checks
 
 Task

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -36,14 +36,14 @@ About this Task
        - Sync jobs that are running with :ref:`Kafka support <kafka-intro>`.
 
 - Examples of embedded mode recoverable scenarios include:
-
-   - Unexpected application failure
-   - Operating system restarts
+  
+  - Unexpected application failure
+  - Operating system restarts
 
 - Examples of Kafka CDC sync job recoverable scenarios include:
-
-   - Loss of individual `brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__ in Kafka cluster
-   - Application-level issues resulting in failed health checks
+  
+  - Loss of individual `brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__ in Kafka cluster
+  - Application-level issues resulting in failed health checks
 
 Task
 ----
@@ -59,11 +59,11 @@ for each deployment mode.
       For embedded mode recovery, the process to restart
       a sync job is manually trigger. 
       
-         .. procedure::
+      .. procedure::
 
-            .. step:: Navigate to the :guilabel:`Data Migration` tab
+         .. step:: Navigate to the :guilabel:`Data Migration` tab
 
-            .. step:: Click :guilabel:`Resume` on the failed sync job. 
+         .. step:: Click :guilabel:`Resume` on the failed sync job. 
 
    .. tab:: Kafka Mode
       :tabid: kafka-mode

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -38,6 +38,9 @@ mode your using. The following table summarizes the modes:
 Task
 ----
 
+Click the tab for the deployment mode your using 
+to display the recovery procedure.
+
 .. tabs::
 
    .. tab:: Embedded Mode

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -57,13 +57,14 @@ for each deployment mode.
       :tabid: embedded-mode
 
       For embedded mode recovery, the process to restart
-      a sync job is manually trigger. 
-      
+      a sync job is manually triggered. Recovery may require 
+      restarting Relational Migrator.
+
       .. procedure::
 
          .. step:: Navigate to the :guilabel:`Data Migration` tab
 
-         .. step:: Click :guilabel:`Resume` on the failed sync job. 
+         .. step:: Click :guilabel:`Resume` on the failed sync job 
 
    .. tab:: Kafka Mode
       :tabid: kafka-mode

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -38,8 +38,8 @@ mode your using. The following table summarizes the modes:
 Task
 ----
 
-Click the tab for the deployment mode your using 
-to display the recovery procedure.
+Click the tab to display the recovery procedure 
+for deployment mode. 
 
 .. tabs::
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -57,8 +57,8 @@ for each deployment mode.
       :tabid: embedded-mode
 
       For embedded mode recovery, the process to restart
-      a sync job is manually triggered. Recovery may require 
-      restarting Relational Migrator.
+      a sync job is manually triggered. This process requires 
+      restarting the Relational Migrator application.
 
       .. procedure::
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -29,11 +29,11 @@ mode your using. The following table summarizes the modes:
      - Description
 
    * - Embedded Mode
-     - Sync jobs are running on a :ref:`local machine <local-machine-install>` or 
+     - Sync jobs that are running on a :ref:`local machine <local-machine-install>` or 
        a :ref:`unattended server <unattended-server>`.
 
    * - Kafka Mode
-     - Sync jobs are running with :ref:`Kafka support <kafka-intro>`.
+     - Sync jobs that are running with :ref:`Kafka support <kafka-intro>`.
 
 Task
 ----

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -39,7 +39,7 @@ Task
 ----
 
 Click the tab to display the recovery procedure 
-for each deployment mode. 
+for each deployment mode:
 
 .. tabs::
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -63,7 +63,7 @@ for each deployment mode:
       a sync job is automatic. Kafka health checks automatically 
       attempt to resume CDC sync jobs after a failure of 
       individual `Kafka brokers <https://developer.confluent.io/courses/apache-kafka/brokers/>`__
-      for up to 24-hours.
+      for up to 24 hours.
 
       Examples of Kafka CDC sync job recoverable scenarios include:
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -19,8 +19,7 @@ About this Task
 ---------------
 
 CDC sync job recovery depends on the type of deployment 
-mode your using. The following table summarizes the different 
-modes:
+mode your using. The following table summarizes the modes:
 
 .. list-table::
    :header-rows: 1

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -1,0 +1,44 @@
+.. _rm-sync-jobs-recoverability
+
+==================
+Recover a Sync Job
+==================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Relational Migrator can recover continuous syncs jobs that are 
+terminated unexpectedly within a 24-hour period. Procedures for 
+recovering your sync job depend on if your using the embedded 
+or Kafka deployment mode.
+
+Embedded Mode Manual Recovery
+-----------------------------
+
+For embedded mode recovery, the process to restart
+a sync job is manually trigger. Navigate to the 
+:guilabel:`Data Migration` tab and click 
+:guilabel:`Resume` on the failed sync job. 
+
+Examples of embedded mode recoverable scenarios include:
+
+- Unexpected application failure
+- Operating system restarts
+
+Kafka Deployment Mode Automatic Recovery
+----------------------------------------
+
+For Kafka deployment mode recovery, the process to restart
+a sync job is automatic.Kafka health checks automatically 
+attempt to resume CDC sync jobs after a failure of 
+individual Kafka brokers for up to 24-hours.
+
+Examples of Kafka CDC sync job recoverable scenarios include:
+
+- Loss of individual brokers in Kafka cluster
+- Application-level issues resulting in failed health check
+
+

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -15,8 +15,8 @@ terminated unexpectedly within a 24-hour period. Procedures for
 recovering your sync job depend on if your using the embedded 
 or Kafka deployment mode.
 
-Embedded Mode Manual Recovery
------------------------------
+Embedded Mode Recovery
+----------------------
 
 For embedded mode recovery, the process to restart
 a sync job is manually trigger. Navigate to the 
@@ -28,11 +28,11 @@ Examples of embedded mode recoverable scenarios include:
 - Unexpected application failure
 - Operating system restarts
 
-Kafka Deployment Mode Automatic Recovery
-----------------------------------------
+Kafka Deployment Mode Recovery
+------------------------------
 
-For Kafka deployment mode recovery, the process to restart
-a sync job is automatic.Kafka health checks automatically 
+For the Kafka deployment mode recovery, the process to restart
+a sync job is automatic. Kafka health checks automatically 
 attempt to resume CDC sync jobs after a failure of 
 individual Kafka brokers for up to 24-hours.
 

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -10,8 +10,8 @@ Recover a Sync Job
    :depth: 1
    :class: singlecol
 
-Relational Migrator can recover continuous (CDC) sync jobs that 
-have failed within the preceding 24-hour period. 
+Relational Migrator can attempt to recover continuous (CDC) sync jobs 
+that have failed within the preceding 24-hour period. 
 The procedure for recovering a CDC sync job differs, 
 depending on whether you're using the embedded or Kafka deployment 
 mode, for details on each job type see :ref:`rm-sync-jobs`.

--- a/source/jobs/recover-jobs.txt
+++ b/source/jobs/recover-jobs.txt
@@ -39,7 +39,7 @@ Task
 ----
 
 Click the tab to display the recovery procedure 
-for deployment mode. 
+for each deployment mode. 
 
 .. tabs::
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -35,26 +35,12 @@ data remain in sync.
    For more details about the Kafka deployment model, see 
    :ref:`kafka-intro`.
 
-.. _rm-sync-jobs-recover:
-
 Recoverability
 --------------
 
 Relational Migrator can recover continuous syncs jobs that are 
-terminated unexpectedly within a 24-hour period. Examples of 
-outage scenarios include:
-
-- Network connectivity issues
-- Database connectivity issues
-- Operating system restarts
-- Application failures
-- Loss of individual brokers in a Kafka cluster 
-  (Kafka deployment model only)
-
-Relational Migrator automatically restarts Kafka CDC jobs if the 
-application restarts or crashes unexpectedly. To restart a 
-continuous sync job that failed in embedded mode, navigate to the 
-:guilabel:`Data Migration` tab and click :guilabel:`Resume`.
+terminated unexpectedly within a 24-hour period. For details
+see :ref:`rm-sync-jobs-recoverability`.
 
 Get Started
 -----------
@@ -81,5 +67,6 @@ You can perform the following tasks from the **Data Migration** tab.
    /jobs/creating-jobs
    /jobs/monitoring-jobs
    /jobs/stopping-jobs
+   /jobs/recover-jobs
    /jobs/pause-resume-kafka-jobs
    /jobs/data-verification/data-verification

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -35,6 +35,8 @@ data remain in sync.
    For more details about the Kafka deployment model, see 
    :ref:`kafka-intro`.
 
+.. _rm-sync-jobs-recover:
+
 Recoverability
 --------------
 
@@ -49,10 +51,7 @@ outage scenarios include:
 - Loss of individual brokers in a Kafka cluster 
   (Kafka deployment model only)
 
-Relational Migrator automatically restarts Kafka CDC jobs when the 
-application restarts. To restart a continuous sync job that is
-running in embedded mode navigate to the 
-:guilabel:`Data Migration` tab and click :guilabel:`Resume`.
+.. include:: /includes/fact-resume-cdc-jobs.rst
 
 Get Started
 -----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -51,7 +51,10 @@ outage scenarios include:
 - Loss of individual brokers in a Kafka cluster 
   (Kafka deployment model only)
 
-.. include:: /includes/fact-resume-cdc-jobs.rst
+Relational Migrator automatically restarts Kafka CDC jobs if the 
+application restarts or crashes unexpectedly. To restart a 
+continuous sync job that failed in embedded mode, navigate to the 
+:guilabel:`Data Migration` tab and click :guilabel:`Resume`.
 
 Get Started
 -----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -50,9 +50,9 @@ scenarios include:
   (Kafka deployment model only)
 
 Relational Migrator automatically restarts Kafka CDC jobs when the 
-application restarts. To restart a continuous sync job in embedded mode
-navigate to the :guilabel:`Data Migration` tab and click 
-:guilabel:`Resume`.
+application restarts. To restart a continuous sync job that is
+running in embedded mode navigate to the 
+:guilabel:`Data Migration` tab and click :guilabel:`Resume`.
 
 Get Started
 -----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -39,8 +39,8 @@ Recoverability
 --------------
 
 Relational Migrator can recover continuous syncs jobs that are 
-terminated unexpectedly within a 24-hour period. Example of outage 
-scenarios include:
+terminated unexpectedly within a 24-hour period. Examples of 
+outage scenarios include:
 
 - Network connectivity issues
 - Database connectivity issues

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -45,7 +45,7 @@ scenarios include:
 - Network connectivity issues
 - Database connectivity issues
 - Operating system restarts
-- Application failures and unexpected restarts
+- Application failures
 - Loss of individual brokers in a Kafka cluster 
   (Kafka deployment model only)
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -35,6 +35,23 @@ data remain in sync.
    For more details about the Kafka deployment model, see 
    :ref:`kafka-intro`.
 
+Recoverability
+--------------
+
+Relational Migrator can recover continuous syncs jobs that are 
+terminated unexpectedly within a 24-hour period. Example of outage 
+scenarios include:
+
+- Network connectivity issues
+- Database connectivity issues
+- Operating system restarts
+- Application failures and unexpected restarts
+
+Relational Migrator automatically restarts Kafka CDC jobs when the 
+application restarts. To restart a continuous sync job in embedded mode
+navigate to the :guilabel:`Data Migration` tab and click 
+:guilabel:`Resume`.
+
 Get Started
 -----------
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -38,9 +38,7 @@ data remain in sync.
 Recoverability
 --------------
 
-Relational Migrator can recover continuous syncs jobs that are 
-terminated unexpectedly within a 24-hour period. For details
-see :ref:`rm-sync-jobs-recoverability`.
+.. include:: /includes/fact-cdc-recoverable.rst
 
 Get Started
 -----------

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -46,6 +46,8 @@ scenarios include:
 - Database connectivity issues
 - Operating system restarts
 - Application failures and unexpected restarts
+- Loss of individual brokers in a Kafka cluster 
+  (Kafka deployment model only)
 
 Relational Migrator automatically restarts Kafka CDC jobs when the 
 application restarts. To restart a continuous sync job in embedded mode


### PR DESCRIPTION
## DESCRIPTION

- Adds `recover a sync job` page that outlines how to recover a failed sync job.
- Add small note to the create sync job page att section.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39099/jobs/sync-jobs/#recoverability

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39099/jobs/recover-jobs/

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-39099/jobs/creating-jobs/

## JIRA

https://jira.mongodb.org/browse/DOCSP-39099

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66a0694826eba79552a04f64

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)