### PR TITLE
DOCSP-42513-correct-source-common-name

### DIFF
--- a/source/installation/kafka-deployments/advanced-settings.txt
+++ b/source/installation/kafka-deployments/advanced-settings.txt
@@ -77,20 +77,20 @@ Provide optional configuration settings by updating your ``user.properties`` fil
     retriable failure. Relational Migrator attempts recovery from source database 
     retriable failures up to a set limit before the job fails.
 
-   ``migrator.connector.sink.common.errors.retry.initial.max.ms``
+   ``migrator.connector.source.common.errors.retry.initial.max.ms``
     *Default*: 30000 ms
 
     For the source connector, it specifies the delay in milliseconds to start 
     again after a retriable failure. The value is doubled after every retry but 
-    does not exceed ``migrator.connector.sink.common.errors.retry.delay.max.ms``.
+    does not exceed ``migrator.connector.source.common.errors.retry.delay.max.ms``.
 
-   ``migrator.connector.sink.common.errors.retry.delay.max.ms``
+   ``migrator.connector.source.common.errors.retry.delay.max.ms``
     *Default*: 60000 ms
 
     For the source connector, it specifies the maximum delay in milliseconds 
     between retries after a retriable failure.
 
-   ``migrator.connector.source.common.errors.max.retries``
+   ``migrator.connector.sink.common.errors.max.retries``
     *Default*: 5
     
     For the sink connector, it specifies the maximum number of retries on a 
@@ -145,7 +145,7 @@ Relational Migrator sets default `Debezium source connector properties
 <https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-connector-properties>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.sink.common``. For example: 
+``migrator.connector.source.common``. For example: 
 
 .. code-block::
 
@@ -161,11 +161,11 @@ Relational Migrator sets default Migrator `sink connector properties
 <https://docs.confluent.io/platform/current/installation/configuration/connect/sink-connect-configs.html>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.sink.common``. For example:
+``migrator.connector.source.common``. For example:
 
 .. code-block::
 
-   migrator.connector.source.common.errors.max.retries: 0
+   migrator.connector.sink.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.

--- a/source/installation/kafka-deployments/advanced-settings.txt
+++ b/source/installation/kafka-deployments/advanced-settings.txt
@@ -70,7 +70,7 @@ Provide optional configuration settings by updating your ``user.properties`` fil
     
     Cleans up the topics created during the last migration job.
 
-   ``migrator.connector.sink.common.errors.max.retries``
+   ``migrator.connector.source.common.errors.max.retries``
     *Default*: 5
 
     For the source connector, it specifies the maximum number of retries on a 
@@ -90,7 +90,7 @@ Provide optional configuration settings by updating your ``user.properties`` fil
     For the source connector, it specifies the maximum delay in milliseconds 
     between retries after a retriable failure.
 
-   ``migrator.connector.sink.common.errors.max.retries``
+   ``migrator.connector.source.common.errors.max.retries``
     *Default*: 5
     
     For the sink connector, it specifies the maximum number of retries on a 
@@ -149,7 +149,7 @@ overridden by adding them in the ``user.properties`` file with the prefix
 
 .. code-block::
 
-   migrator.connector.sink.common.errors.max.retries: 0
+   migrator.connector.source.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.
@@ -165,7 +165,7 @@ overridden by adding them in the ``user.properties`` file with the prefix
 
 .. code-block::
 
-   migrator.connector.sink.common.errors.max.retries: 0
+   migrator.connector.source.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.

--- a/source/installation/kafka-deployments/advanced-settings.txt
+++ b/source/installation/kafka-deployments/advanced-settings.txt
@@ -145,11 +145,11 @@ Relational Migrator sets default `Debezium source connector properties
 <https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-connector-properties>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.source.common``. For example: 
+``migrator.connector.sink.common``. For example: 
 
 .. code-block::
 
-   migrator.connector.source.common.errors.max.retries: 0
+   migrator.connector.sink.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.

--- a/source/installation/kafka-deployments/advanced-settings.txt
+++ b/source/installation/kafka-deployments/advanced-settings.txt
@@ -70,21 +70,21 @@ Provide optional configuration settings by updating your ``user.properties`` fil
     
     Cleans up the topics created during the last migration job.
 
-   ``migrator.connector.source.common.errors.max.retries``
+   ``migrator.connector.sink.common.errors.max.retries``
     *Default*: 5
 
     For the source connector, it specifies the maximum number of retries on a 
     retriable failure. Relational Migrator attempts recovery from source database 
     retriable failures up to a set limit before the job fails.
 
-   ``migrator.connector.source.common.errors.retry.initial.max.ms``
+   ``migrator.connector.sink.common.errors.retry.initial.max.ms``
     *Default*: 30000 ms
 
     For the source connector, it specifies the delay in milliseconds to start 
     again after a retriable failure. The value is doubled after every retry but 
-    does not exceed ``migrator.connector.source.common.errors.retry.delay.max.ms``.
+    does not exceed ``migrator.connector.sink.common.errors.retry.delay.max.ms``.
 
-   ``migrator.connector.source.common.errors.retry.delay.max.ms``
+   ``migrator.connector.sink.common.errors.retry.delay.max.ms``
     *Default*: 60000 ms
 
     For the source connector, it specifies the maximum delay in milliseconds 
@@ -145,11 +145,11 @@ Relational Migrator sets default `Debezium source connector properties
 <https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-connector-properties>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.source.common``. For example: 
+``migrator.connector.sink.common``. For example: 
 
 .. code-block::
 
-   migrator.connector.source.common.errors.max.retries: 0
+   migrator.connector.sink.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.
@@ -161,7 +161,7 @@ Relational Migrator sets default Migrator `sink connector properties
 <https://docs.confluent.io/platform/current/installation/configuration/connect/sink-connect-configs.html>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.source.common``. For example:
+``migrator.connector.sink.common``. For example:
 
 .. code-block::
 

--- a/source/installation/kafka-deployments/advanced-settings.txt
+++ b/source/installation/kafka-deployments/advanced-settings.txt
@@ -145,11 +145,11 @@ Relational Migrator sets default `Debezium source connector properties
 <https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-connector-properties>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.sink.common``. For example: 
+``migrator.connector.source.common``. For example: 
 
 .. code-block::
 
-   migrator.connector.sink.common.errors.max.retries: 0
+   migrator.connector.source.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
 there is no retries after a retriable failure.
@@ -161,11 +161,11 @@ Relational Migrator sets default Migrator `sink connector properties
 <https://docs.confluent.io/platform/current/installation/configuration/connect/sink-connect-configs.html>`__
 for each supported source database. The connector properties can be 
 overridden by adding them in the ``user.properties`` file with the prefix 
-``migrator.connector.source.common``. For example:
+``migrator.connector.sink.common``. For example:
 
 .. code-block::
 
    migrator.connector.sink.common.errors.max.retries: 0
 
 In this example, the default value is five but it has now been set to zero. This means
-there is no retries after a retriable failure.
+there are no retries.


### PR DESCRIPTION
## DESCRIPTION

- Fixing naming error `migrator.connector.source.common` should be `migrator.connector.sink.common`.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/docs-relational-migrator/DOCSP-42513/installation/kafka-deployments/advanced-settings/#sink-connector-properties

## JIRA

https://jira.mongodb.org/browse/DOCSP-42513

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66bbba398383957117cf6fff

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)