### PR TITLE
DOCSP-42470-plugin-spelling-change

### DIFF
--- a/source/installation/kafka-deployments/migrator-with-kafka.txt
+++ b/source/installation/kafka-deployments/migrator-with-kafka.txt
@@ -19,7 +19,7 @@ Integrating Relational Migrator with Kafka
 Relational Migrator uses `Apache Kafka 
 <https://www.mongodb.com/docs/kafka-connector/current/introduction/kafka-connect/#apache-kafka>`__ 
 as a robust transport layer to migrate data from a source relational database 
-to MongoDB. Relational Migrator can be used as a Kafka Connect plug-in that 
+to MongoDB. Relational Migrator can be used as a Kafka Connect plugin that 
 improves resilience and scalability of big data migration jobs.
 
 Use Cases


### PR DESCRIPTION
## DESCRIPTION

Standardize spelling for "plugin". I only found one instance of "plug-in" in the docs that needed to be updated.

## STAGING

[Integrating Relational Migrator with Kafka](https://preview-mongodbjeffallenmongo.gatsbyjs.io/docs-relational-migrator/DOCSP-42470/installation/kafka-deployments/migrator-with-kafka/#integrating-relational-migrator-with-kafka)

## JIRA

https://jira.mongodb.org/browse/DOCSP-42470

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66bfaf018e811ae6728621ad

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)