### PR TITLE
DOCSP-43292-Incorrect-path-install-mac-drivers

### DIFF
--- a/source/installation/install-on-a-local-machine/install-mac.txt
+++ b/source/installation/install-on-a-local-machine/install-mac.txt
@@ -30,7 +30,7 @@ Steps
    
       .. include:: /includes/fact-driver-download-locations.rst
 
-   b. Copy the driver files to ``/Library/Application Support/MongoDB/Relational Migrator/Drivers``.
+   b. Copy the driver files to ``~/Library/Application Support/MongoDB/Relational Migrator/Drivers``.
 
       .. note::
 


### PR DESCRIPTION
## DESCRIPTION
Updating path for drivers when installing on MacOS.

## STAGING
[Install on Mac (Step 4b)](https://deploy-preview-165--docs-relational-migrator.netlify.app/installation/install-on-a-local-machine/install-mac/#steps)

## JIRA
https://jira.mongodb.org/browse/DOCSP-43292

## BUILD LOG
https://app.netlify.com/sites/docs-relational-migrator/deploys/66e331806f67b60008eed000

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)