### PR TITLE
DOCSP-43140-Update-Debezium-Source-Version-to-2.7.0

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -43,6 +43,7 @@ toc_landing_pages = [
 ]
 
 [constants]
+connector-version = "2.7.0"
 ddl = ":abbr:`DDL (Data Definition Language)`"
 job = "sync job" #this will be updated to migration job in the near future.
 job_plural = "sync jobs" #this will be updated to migration jobs in the near future.
@@ -58,4 +59,3 @@ variant = "warning"
 value = """\
         DB2 and Sybase database support is currently in public preview. Users looking for production-grade migration assistance, please contact your account representative to engage in a guided evaluation. 
         """
-

--- a/source/installation/kafka-deployments/install-kafka-cluster.txt
+++ b/source/installation/kafka-deployments/install-kafka-cluster.txt
@@ -37,13 +37,13 @@ Steps
       a. Download the source connector archive for your source database:
 
          - `MySQL Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/2.7.0.Final/debezium-connector-mysql-2.7.0.Final-plugin.tar.gz>`__
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/{+connector-version+}.Final/debezium-connector-mysql-{+connector-version+}.Final-plugin.tar.gz>`__
          - `Postgres Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.7.0.Final/debezium-connector-postgres-2.7.0.Final-plugin.tar.gz>`__
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{+connector-version+}.Final/debezium-connector-postgres-{+connector-version+}.Final-plugin.tar.gz>`__
          - `SQL Server Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/2.7.0.Final/debezium-connector-sqlserver-2.7.0.Final-plugin.tar.gz>`__ 
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{+connector-version+}.Final/debezium-connector-sqlserver-{+connector-version+}.Final-plugin.tar.gz>`__ 
          - `Oracle Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/2.7.0.Final/debezium-connector-oracle-2.7.0.Final-plugin.tar.gz>`__  
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/{+connector-version+}.Final/debezium-connector-oracle-{+connector-version+}.Final-plugin.tar.gz>`__  
 
       b. Unzip the archive.
 

--- a/source/installation/kafka-deployments/install-kafka-cluster.txt
+++ b/source/installation/kafka-deployments/install-kafka-cluster.txt
@@ -37,13 +37,13 @@ Steps
       a. Download the source connector archive for your source database:
 
          - `MySQL Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/2.4.1.Final/debezium-connector-mysql-2.4.1.Final-plugin.tar.gz>`__
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/2.7.0.Final/debezium-connector-mysql-2.7.0.Final-plugin.tar.gz>`__
          - `Postgres Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.4.1.Final/debezium-connector-postgres-2.4.1.Final-plugin.tar.gz>`__
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.7.0.Final/debezium-connector-postgres-2.7.0.Final-plugin.tar.gz>`__
          - `SQL Server Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/2.4.1.Final/debezium-connector-sqlserver-2.4.1.Final-plugin.tar.gz>`__ 
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/2.7.0.Final/debezium-connector-sqlserver-2.7.0.Final-plugin.tar.gz>`__ 
          - `Oracle Connector plugin archive 
-           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/2.4.1.Final/debezium-connector-oracle-2.4.1.Final-plugin.tar.gz>`__  
+           <https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/2.7.0.Final/debezium-connector-oracle-2.7.0.Final-plugin.tar.gz>`__  
 
       b. Unzip the archive.
 


### PR DESCRIPTION
## DESCRIPTION
Updating Debezium links on Kafka Cluster Installation to version `2.7.0` final.

## STAGING
[Install with an Existing Kafka Cluster (Step 1)](https://deploy-preview-166--docs-relational-migrator.netlify.app/installation/kafka-deployments/install-kafka-cluster/#install-debezium-source-connect-plugin)

## JIRA
https://jira.mongodb.org/browse/DOCSP-43140

## BUILD LOG
https://app.netlify.com/sites/docs-relational-migrator/deploys/66e336c25506d40007be00af

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)