### PR TITLE
DOCSP-44455-incorrect-heading-text

### DIFF
--- a/source/connection-strings/connection-strings.txt
+++ b/source/connection-strings/connection-strings.txt
@@ -28,4 +28,4 @@ Get Started
    :hidden:
 
    MongoDB Database </connection-strings/mongodb-database-connection-strings>
-   Relational Migrator </connection-strings/relational-database-connection-strings>
+   Relational Database </connection-strings/relational-database-connection-strings>


### PR DESCRIPTION
## DESCRIPTION
Replacing the ToC entry for `Connection Strings` > `Relational Database`. (Was `Connection Strings` > `Relational Migrator`).

## STAGING
[Connection Strings](https://deploy-preview-174--docs-relational-migrator.netlify.app/connection-strings/connection-strings/) (See ToC entry underneath `Connection Strings`)

## JIRA
https://jira.mongodb.org/browse/DOCSP-44455

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)