### PR TITLE
DOCSP-43831-DB2-and-Sybase-database-support

### DIFF
--- a/source/getting-started/supported-databases.txt
+++ b/source/getting-started/supported-databases.txt
@@ -38,26 +38,34 @@ Relational Migrator supports the following source databases:
      - Supported Versions 
      - Deployments 
 
-   * - Oracle 
+   * - :ref:`Oracle <rm-prereq-oracle>`
      - 11g and higher
      - Self hosted, AWS RDS
 
-   * - Microsoft SQL Server
+   * - :ref:`Microsoft SQL Server <rm-prereq-sqlserver>`
      - 2012 and higher (Enterprise or Developer edition required for
        versions before 2016)
      - Self hosted, AWS RDS, Azure SQL Database
 
-   * - PostgreSQL [1]_
+   * - :ref:`PostgreSQL <rm-prereq-postgres>`
      - 10 and higher
      - Self hosted, AWS RDS/Aurora, Azure Database
 
-   * - MySQL
+   * - `TimescaleDB hypertables <https://docs.timescale.com/use-timescale/latest/hypertables/>`
+     - 10 and higher
+     - Self hosted, AWS RDS/Aurora, Azure Database
+
+   * - :ref:`MySQL <rm-prereq-mysql>`
      - 5.7 and higher
      - Self hosted, AWS RDS/Aurora, Azure Database
 
-   * - Sybase ASE
+   * - :ref:`Sybase ASE <rm-prereq-sybase>` (Public Preview)
      - 15 and higher (Sybase IQ not supported)
      - Self hosted
+
+   * - :ref:`DB2 <rm-prereq-db2>` (Public Preview)
+     - [TBD]
+     - Self hosted, AWS RDS
 
 .. [1] `TimescaleDB hypertables <https://docs.timescale.com/use-timescale/latest/hypertables/>`__ are supported for PostgreSQL. 
 

--- a/source/getting-started/supported-databases.txt
+++ b/source/getting-started/supported-databases.txt
@@ -64,7 +64,7 @@ Relational Migrator supports the following source databases:
      - Self hosted
 
    * - :ref:`DB2 <rm-prereq-db2>` (Public Preview)
-     - [11.5 and higher
+     - 11.5 and higher
      - Self hosted, AWS RDS 
 
 MongoDB Databases and Versions

--- a/source/getting-started/supported-databases.txt
+++ b/source/getting-started/supported-databases.txt
@@ -51,7 +51,7 @@ Relational Migrator supports the following source databases:
      - 10 and higher
      - Self hosted, AWS RDS/Aurora, Azure Database
 
-   * - `TimescaleDB hypertables <https://docs.timescale.com/use-timescale/latest/hypertables/>`
+   * - `TimescaleDB hypertables <https://docs.timescale.com/use-timescale/latest/hypertables/>`__
      - 10 and higher
      - Self hosted, AWS RDS/Aurora, Azure Database
 
@@ -65,9 +65,7 @@ Relational Migrator supports the following source databases:
 
    * - :ref:`DB2 <rm-prereq-db2>` (Public Preview)
      - [TBD]
-     - Self hosted, AWS RDS
-
-.. [1] `TimescaleDB hypertables <https://docs.timescale.com/use-timescale/latest/hypertables/>`__ are supported for PostgreSQL. 
+     - Self hosted, AWS RDS 
 
 MongoDB Databases and Versions
 ------------------------------

--- a/source/getting-started/supported-databases.txt
+++ b/source/getting-started/supported-databases.txt
@@ -64,7 +64,7 @@ Relational Migrator supports the following source databases:
      - Self hosted
 
    * - :ref:`DB2 <rm-prereq-db2>` (Public Preview)
-     - [TBD]
+     - [11.5 and higher
      - Self hosted, AWS RDS 
 
 MongoDB Databases and Versions


### PR DESCRIPTION
## DESCRIPTION

- Added DB2 (Public Preview) to supported databases: Support for Self-hosted and AWS RDS.
- Updated Sybase entry to mention its in Public Preview.
- Linked each database table entry to its Database prerequisite page.
- Moved Timescale into a row under Postgres.

## STAGING
[Supported Databases](https://deploy-preview-175--docs-relational-migrator.netlify.app/getting-started/supported-databases/)

## JIRA
https://jira.mongodb.org/browse/DOCSP-43831

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)