### PR TITLE
DOCSP-44814-project-settings-malformed-code-block

### DIFF
--- a/source/projects/configure-settings.txt
+++ b/source/projects/configure-settings.txt
@@ -71,7 +71,7 @@ inserted into a collection. You can choose one of the following options:
     primary key field.
 
     For example, if your relational table row has a primary key of 
-    ``personId = 1``, after  migration your MongoDB ``_id``field is 
+    ``personId = 1``, after  migration your MongoDB ``_id`` field is 
     ``_id: { personId: 1 }``. 
 
 


### PR DESCRIPTION
## DESCRIPTION
Code block in Configuring Project Settings page in Relational Migrator docs reads:  `_id``field is ``_id: { personId: 1 }`; it should read `_id` field is `_id: { personId: 1 }`

## STAGING
https://deploy-preview-179--docs-relational-migrator.netlify.app/projects/configure-settings/#configurable-project-settings

## JIRA
https://jira.mongodb.org/browse/DOCSP-44814

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)