### PR TITLE
(DOCSP-45763) [MIG] Add downloads page link to release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -11,7 +11,7 @@ Release Notes
    :class: twocols
 
 Download the latest Relational Migrator binary from the `release page <https://www.mongodb.com/try/download/relational-migrator>`__. 
-For instructions on installing Relational Migrator, see the :ref:`Installation <installation>` page. 
+For installation instructions, see the :ref:`Installation <installation>` page. 
 
 1.11.0 Changelog
 ----------------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,8 @@ Release Notes
    :depth: 1
    :class: twocols
 
+Download the latest Relational Migrator binary from the `release page <https://www.mongodb.com/try/download/relational-migrator>`__. 
+For instructions on installing Relational Migrator, see the :ref:`Installation <installation>` page. 
 
 1.11.0 Changelog
 ----------------


### PR DESCRIPTION
## DESCRIPTION
Add a one liner with link to https://www.mongodb.com/docs/relational-migrator/release-notes/ showing where to download this release. Users who visit the release notes should be able to easily down

## [STAGING](https://deploy-preview-185--docs-relational-migrator.netlify.app/release-notes/)


## JIRA
[DOCSP-45763](https://jira.mongodb.org/browse/DOCSP-45763)

## [BUILD LOG](https://app.netlify.com/sites/docs-relational-migrator/deploys/6750a32ee96b1200080fd084)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)