### PR TITLE
(DOCSP-45462) [MIG] Mention that CDC jobs ignore table filters

### DIFF
--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -25,7 +25,7 @@ migration strategy.
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
 followed by a CDC stage that captures database updates in near-real time. The CDC stage 
-updates all database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
+updates all changed database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
 When you run a continuous migration job, your source and destination database 
 data remain in sync.
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -24,8 +24,8 @@ migration strategy.
 
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
-followed by a CDC stage that captures database updates in near-real time. Continuous jobs
-update all database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
+followed by a CDC stage that captures database updates in near-real time. The CDC stage
+updates all changed database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
 When you run a continuous migration job, your source and destination database 
 data remain in sync.
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -20,11 +20,13 @@ Types of Migration Jobs
 Relational Migrator offers two different migration job types:
 
 **Snapshot**: Snapshot migration jobs run once, typically for a point in time 
-migration strategy.
+migration strategy. You can apply :ref:`table filters <rm-table-filters>` to control the 
+volume of data migrated from each table in a snapshot migration job.
 
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
-followed by a CDC stage that captures database updates in near-real time. 
+followed by a CDC stage that captures database updates in near-real time. The CDC stage 
+updates all database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
 When you run a continuous migration job, your source and destination database 
 data remain in sync.
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -25,7 +25,7 @@ migration strategy.
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
 followed by a CDC stage that captures database updates in near-real time. The CDC stage
-updates all changed database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
+updates all new or modified database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
 When you run a continuous migration job, your source and destination database 
 data remain in sync.
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -24,8 +24,8 @@ migration strategy.
 
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,
-followed by a CDC stage that captures database updates in near-real time. The CDC stage 
-updates all changed database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
+followed by a CDC stage that captures database updates in near-real time. Continuous jobs
+update all database objects, ignoring any :ref:`rm-table-filters` set in project-level mapping rules. 
 When you run a continuous migration job, your source and destination database 
 data remain in sync.
 

--- a/source/jobs/sync-jobs.txt
+++ b/source/jobs/sync-jobs.txt
@@ -20,8 +20,7 @@ Types of Migration Jobs
 Relational Migrator offers two different migration job types:
 
 **Snapshot**: Snapshot migration jobs run once, typically for a point in time 
-migration strategy. You can apply :ref:`table filters <rm-table-filters>` to control the 
-volume of data migrated from each table in a snapshot migration job.
+migration strategy.
 
 **Continuous**: Continuous migration jobs cover new incoming data for a zero-downtime 
 Change Data Capture (CDC) migration strategy. Continuous jobs run a snapshot stage first,

--- a/source/table-filters/table-filters.txt
+++ b/source/table-filters/table-filters.txt
@@ -20,8 +20,8 @@ Table filters allow you to:
 - Limit the read operations on your source database.
 - Create test environments before migrating your entire database.
 
-Table filters apply to any snapshot migration job that you create in your Relational Migrator project. 
-Continuous migration jobs ignore project-level table filters, and always update all database objects. 
+Migration jobs apply project-level table filters during the initial snapshot stage. During a continuous migration job, 
+the CDC stage ignores table filters and updates all new or modified database objects. 
 To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
 
 Table Filter Types

--- a/source/table-filters/table-filters.txt
+++ b/source/table-filters/table-filters.txt
@@ -21,9 +21,9 @@ Table filters allow you to:
 - Create test environments before migrating your entire database.
 
 .. note:: 
-   
-   Table filters only apply to snapshot migration jobs in your migration project.
-   Continuous migration jobs ignore project-level table filters and always update all database objects.
+
+   Table filters apply to all snapshot migration jobs in a migration project. 
+   Continuous migration jobs always update all database objects, ignoring project-level table filters. 
    To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
 
 Table Filter Types

--- a/source/table-filters/table-filters.txt
+++ b/source/table-filters/table-filters.txt
@@ -22,8 +22,8 @@ Table filters allow you to:
 
 .. note:: 
 
-   Table filters apply to all snapshot migration jobs in a migration project. 
-   Continuous migration jobs always update all database objects, ignoring project-level table filters. 
+   Table filters apply to all snapshot migration jobs in a project. 
+   Continuous migration jobs ignore project-level table filters, always updating all database objects. 
    To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
 
 Table Filter Types

--- a/source/table-filters/table-filters.txt
+++ b/source/table-filters/table-filters.txt
@@ -20,11 +20,9 @@ Table filters allow you to:
 - Limit the read operations on your source database.
 - Create test environments before migrating your entire database.
 
-.. note:: 
-
-   Table filters apply to all snapshot migration jobs in a project. 
-   Continuous migration jobs ignore project-level table filters, always updating all database objects. 
-   To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
+Table filters apply to any snapshot migration job that you create in your Relational Migrator project. 
+Continuous migration jobs ignore project-level table filters, and always update all database objects. 
+To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
 
 Table Filter Types
 ------------------

--- a/source/table-filters/table-filters.txt
+++ b/source/table-filters/table-filters.txt
@@ -20,6 +20,12 @@ Table filters allow you to:
 - Limit the read operations on your source database.
 - Create test environments before migrating your entire database.
 
+.. note:: 
+   
+   Table filters only apply to snapshot migration jobs in your migration project.
+   Continuous migration jobs ignore project-level table filters and always update all database objects.
+   To learn more about types of migration jobs, see :ref:`rm-sync-jobs`. 
+
 Table Filter Types
 ------------------
 


### PR DESCRIPTION
## DESCRIPTION
Mention that snapshot jobs use table filters if present, but CDC jobs always ignore snapshot table filters and will update all database objects. From discussion at https://github.com/mongodb/docs-relational-migrator/pull/177

## STAGING
- [Migration Jobs](https://deploy-preview-187--docs-relational-migrator.netlify.app/jobs/sync-jobs/)
- [Table Filters](https://deploy-preview-187--docs-relational-migrator.netlify.app/table-filters/table-filters/) 

## [DOCSP-45462](https://jira.mongodb.org/browse/DOCSP-45462)

## [BUILD LOG](https://app.netlify.com/sites/docs-relational-migrator/deploys/6759edab19c5790008ceee81)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)