### PR TITLE
DOCSP-45339 Update Oracle migration prerequisites

### DIFF
--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -17,6 +17,19 @@ a. Create a service account:
 
       CREATE USER '<user>'@'localhost' IDENTIFIED BY '<password>';
 
+#. Check if the service account owns the tables in the migration job.
+
+   Required permissions depend on whether the service account owns the tables
+   used in the migration job. To check table ownership run the following query:
+
+   .. code-block:: sql
+      :copyable: true
+
+      SELECT TABLE_NAME, OWNER 
+      FROM ALL_TABLES 
+      WHERE TABLE_NAME ='<table_name>'
+      ORDER BY OWNER, TABLE_NAME;
+
 #. Grant permissions to the service account.
 
    .. important::
@@ -29,18 +42,6 @@ a. Create a service account:
          :copyable: false
       
          GRANT CREATE SESSION TO <user> CONTAINER=ALL;
-
-   Required permissions depend on whether the service account owns the tables
-   used in the migration job. To check table ownership run the following query:
-
-   .. code-block:: sql
-      :copyable: true
-
-      SELECT TABLE_NAME, OWNER 
-      FROM ALL_TABLES 
-      WHERE TABLE_NAME ='<table_name>'
-      ORDER BY OWNER, TABLE_NAME;
-   
    
    If the service account *is* the table owner:
 

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -35,7 +35,7 @@ a. Create a service account:
    .. important::
       
       If you're migrating a multi-tenant container database as a
-      common user, append ``CONTAINER=ALL`` to each permission, for
+      common user, append ``CONTAINER=ALL`` when granting permissions, for
       example:
 
       .. code-block:: sql

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -17,7 +17,7 @@ a. Create a service account:
 
       CREATE USER '<user>'@'localhost' IDENTIFIED BY '<password>';
 
-#. Grant session creation and select permissions to the service account.
+#. Grant permissions to the service account.
 
    .. important::
       
@@ -30,16 +30,8 @@ a. Create a service account:
       
          GRANT CREATE SESSION TO <user> CONTAINER=ALL;
 
-   .. code-block:: sql
-      :copyable: true
-
-      GRANT CREATE SESSION TO <user>;
-      GRANT SELECT ON V$DATABASE TO <user>;
-
-#. Grant additional permissions if the service account doesn't own the tables
-   used in the migration job.
-
-   To check table ownership, run the following query:
+   Required permissions depend on whether the service account owns the tables
+   used in the migration job. To check table ownership run the following query:
 
    .. code-block:: sql
       :copyable: true
@@ -49,14 +41,22 @@ a. Create a service account:
       WHERE TABLE_NAME ='<table_name>'
       ORDER BY OWNER, TABLE_NAME;
    
-   If the service account *is* the table owner, no additional permissions are
-   needed. If it *isn't* the table owner, add the following. Append
-   ``CONTAINER=ALL`` if migrating a multi-tenant container database as a 
-   common user:
+   
+   If the service account *is* the table owner:
 
    .. code-block:: sql
       :copyable: true
 
+      GRANT CREATE SESSION TO <user>;
+      GRANT SELECT ON V$DATABASE TO <user>;
+
+   If the service account *is not* the table owner:
+
+   .. code-block:: sql
+      :copyable: true
+
+      GRANT CREATE SESSION TO <user>;
       GRANT SELECT_CATALOG_ROLE TO <user>;
       GRANT SELECT ANY TABLE TO <user>;
+      GRANT SELECT ON V$DATABASE TO <user>;
       GRANT FLASHBACK ANY TABLE TO <user>;

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -17,10 +17,10 @@ a. Create a service account:
 
       CREATE USER '<user>'@'localhost' IDENTIFIED BY '<password>';
 
-#. Check if the service account owns the tables in the migration job.
+#. Confirm that the service account owns the tables in the migration job.
 
    Required permissions depend on whether the service account owns the tables
-   used in the migration job. To check table ownership run the following query:
+   used in the migration job. To check table ownership, run the following query:
 
    .. code-block:: sql
       :copyable: true
@@ -35,7 +35,7 @@ a. Create a service account:
    .. important::
       
       If you're migrating a multi-tenant container database as a
-      common user, append ``CONTAINER=ALL`` when granting permissions, for
+      common user, append ``CONTAINER=ALL`` when granting permissions. For
       example:
 
       .. code-block:: sql

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -4,6 +4,11 @@ instance. Alternatively, you can use an existing Oracle
 service account to connect to Relational Migrator with 
 the appropriate permissions.
 
+.. tip::
+
+   To migrate data from a multi-tenant container database, use a `Common
+   User <https://oracle-base.com/articles/12c/multitenant-manage-users-and-privileges-for-cdb-and-pdb-12cr1>`__.
+
 a. Create a service account:
 
    .. code-block:: sql

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -6,9 +6,8 @@ the appropriate permissions.
 
 .. tip::
 
-   To migrate data from a multi-tenant container database, use a `Common
-   User
-   <https://oracle-base.com/articles/12c/multitenant-manage-users-and-privileges-for-cdb-and-pdb-12cr1>`__.
+   To migrate data from a multi-tenant container database, `create tablespaces
+   and a Common User <https://oracle-base.com/articles/12c/multitenant-manage-users-and-privileges-for-cdb-and-pdb-12cr1>`__.
 
 a. Create a service account:
 

--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -7,7 +7,8 @@ the appropriate permissions.
 .. tip::
 
    To migrate data from a multi-tenant container database, use a `Common
-   User <https://oracle-base.com/articles/12c/multitenant-manage-users-and-privileges-for-cdb-and-pdb-12cr1>`__.
+   User
+   <https://oracle-base.com/articles/12c/multitenant-manage-users-and-privileges-for-cdb-and-pdb-12cr1>`__.
 
 a. Create a service account:
 
@@ -16,11 +17,29 @@ a. Create a service account:
 
       CREATE USER '<user>'@'localhost' IDENTIFIED BY '<password>';
 
-#. Grant select permissions to the service account:
+#. Grant session creation and select permissions to the service account.
 
-   The required permission for the service account depend on whether 
-   the tables are owned by the service account used to run the migration job.
-   To check table ownership run the following query:
+   .. important::
+      
+      If you're migrating a multi-tenant container database as a
+      common user, append ``CONTAINER=ALL`` to each permission, for
+      example:
+
+      .. code-block:: sql
+         :copyable: false
+      
+         GRANT CREATE SESSION TO <user> CONTAINER=ALL;
+
+   .. code-block:: sql
+      :copyable: true
+
+      GRANT CREATE SESSION TO <user>;
+      GRANT SELECT ON V$DATABASE TO <user>;
+
+#. Grant additional permissions if the service account doesn't own the tables
+   used in the migration job.
+
+   To check table ownership, run the following query:
 
    .. code-block:: sql
       :copyable: true
@@ -29,22 +48,15 @@ a. Create a service account:
       FROM ALL_TABLES 
       WHERE TABLE_NAME ='<table_name>'
       ORDER BY OWNER, TABLE_NAME;
-
-   If the service account *is* the table owner:
-
-   .. code-block:: sql
-      :copyable: true
-
-      GRANT CREATE SESSION TO <user>;
-      GRANT SELECT ON V$DATABASE TO <user>;
-
-   If the service account *is not* the table owner:
+   
+   If the service account *is* the table owner, no additional permissions are
+   needed. If it *isn't* the table owner, add the following. Append
+   ``CONTAINER=ALL`` if migrating a multi-tenant container database as a 
+   common user:
 
    .. code-block:: sql
       :copyable: true
 
-      GRANT CREATE SESSION TO <user>;
       GRANT SELECT_CATALOG_ROLE TO <user>;
       GRANT SELECT ANY TABLE TO <user>;
-      GRANT SELECT ON V$DATABASE TO <user>;
       GRANT FLASHBACK ANY TABLE TO <user>;

--- a/source/includes/fact-short-sync-job-desc.rst
+++ b/source/includes/fact-short-sync-job-desc.rst
@@ -1,3 +1,3 @@
-- Snapshot migration jobs migrate all data, then stop.
-- Continuous migration job run a snapshot and then enter a CDC stage to 
-  continuously replicate data changes.
+- Snapshot migration jobs migrate all data once, and then stop.
+- Continuous migration jobs run a snapshot migration and then enter a CDC stage, which 
+  continuously replicates data changes.

--- a/source/includes/fact-short-sync-job-desc.rst
+++ b/source/includes/fact-short-sync-job-desc.rst
@@ -1,3 +1,3 @@
-- Snapshot migration jobs migrate all the data and then stops.
+- Snapshot migration jobs migrate all data, then stop.
 - Continuous migration job run a snapshot and then enter a CDC stage to 
   continuously replicate data changes.

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -62,21 +62,21 @@ Steps
 
          .. step:: Set up user permissions
 
+            .. important::
+               
+               If you're migrating a multi-tenant container database as a
+               common user, append ``CONTAINER=ALL`` to each permission, for
+               example:
+
+               .. code-block:: sql
+                  :copyable: false
+               
+                  GRANT CREATE SESSION TO c##common_user CONTAINER=ALL;
+
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
             c. Grant additional permissions to the service account 
                to run continuous migration jobs. 
-               
-               .. important::
-               
-                  If you're migrating a multi-tenant container database as a
-                  common user, append ``CONTAINER=ALL`` to each permission, for
-                  example:
-
-                  .. code-block:: sql
-                     :copyable: false
-                  
-                     GRANT SET CONTAINER TO c##common_user CONTAINER=ALL;
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -67,7 +67,8 @@ Steps
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
             d. Grant additional permissions to the service account 
-               to run continuous migration jobs. 
+               to run continuous migration jobs, appending ``CONTAINER=ALL`` if
+               migrating a multi-tenant container database:
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -10,11 +10,10 @@ Configure Migration Prerequisites for Oracle
    :depth: 1
    :class: singlecol
 
-When you migrate data from an Oracle source database, that database may require 
-configuration changes. If Relational Migrator determines the 
-database needs configuration changes, it automatically generates a 
-SQL script with the required changes. Have a Database Administrator (DBA)
-review the script and run the commands on the database server. 
+When you migrate data from an Oracle source database, Relational Migrator 
+automatically checks your database for needed configuration changes and 
+generates a SQL script to implement them. Have a Database Administrator (DBA)
+review the script and run the commands on the database server.
 
 Oracle configuration depends on the type of migration job:
 
@@ -29,17 +28,14 @@ About this Task
 - If you're migrating from an Oracle 12c instance, you must run commands as 
   the SYSDBA role.
 - Oracle 12c introduced the concept of a pluggable database (PDB). Some
-  of these commands can be run on a PDB (pluggable database), while commands 
-  like enabling ``ARCHIVELOG`` must be run on the
-  container/master database (CDB). For details on each architecture, 
-  see `Overview of Container Databases and Pluggable Databases
-  <https://oracle-base.com/articles/12c/multitenant-overview-container-database-cdb-12cr1>`__.
+  commands can be run on a PDB, while commands like enabling ``ARCHIVELOG``
+  must be run on the container/master database (CDB). For details on each
+  architecture, see `Overview of Container Databases and Pluggable Databases <https://oracle-base.com/articles/12c/multitenant-overview-container-database-cdb-12cr1>`__.
 - Some commands differ based on whether the database is single or
   multi-tenant. In a multi-tenant database, permissions must
   include the suffix ``CONTAINER=ALL``.
-- Oracle Express editions don't support logging the necessary information for
-  continuous migration jobs, so you can't run continuous migration against an
-  Oracle XE database.
+- You can't run a continuous migration job against Oracle Database Express 
+  Edition (XE), because XE doesn't support the necessary logs.
 
 Steps
 -----
@@ -110,11 +106,10 @@ Steps
             
             #. If archive logging isn't already enabled,  enable it. 
             
-               The following is an example of the code Relational Migrator
-               The following code is an example. You can run it manually if you
-               substituting your database name. If you're migrating a
-               multi-tenant database, run these commands on the
-               container/master database.
+               Relational Migrator can automatically generate code to enable
+               logging. The following code is an example. If you're migrating a
+               multi-tenant database, run these commands on the container/
+               master database.
 
                .. code-block:: sql
                   :copyable: true
@@ -128,16 +123,14 @@ Steps
     
          .. step:: Enable supplemental logging
 
-            a. Enable 
-               supplemental logging:
+            a. Enable supplemental logging:
 
                .. code-block:: sql
                   :copyable: true
 
                   ALTER DATABASE ADD SUPPLEMENTAL LOG DATA; 
 
-            #. You must also enable supplemental logging for every 
-               table in the migration:
+            #. Enable supplemental logging for every table in the migration:
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -66,7 +66,7 @@ Steps
 
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
-            c. Grant additional permissions to the service account 
+            d. Grant additional permissions to the service account 
                to run continuous migration jobs. 
 
                .. code-block:: sql

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -64,17 +64,6 @@ Steps
 
          .. step:: Set up user permissions
 
-            .. important::
-               
-               If you're migrating a multi-tenant container database as a
-               common user, append ``CONTAINER=ALL`` to each permission, for
-               example:
-
-               .. code-block:: sql
-                  :copyable: false
-               
-                  GRANT CREATE SESSION TO c##common_user CONTAINER=ALL;
-
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
             c. Grant additional permissions to the service account 

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -14,9 +14,9 @@ When migrating data from an Oracle source database, the database may require
 configuration changes. If Relational Migrator determines the 
 database needs configuration changes, it automatically generates a 
 SQL script with the required changes. Have a Database Administrator (DBA)
-review the script and run the commands on the database server. 
+review the script, then have them run the commands on the database server. 
 
-Oracle configurations depend on the type of migration job:
+Oracle configuration depends on the type of migration job:
 
 .. include:: /includes/fact-short-sync-job-desc.rst
 
@@ -73,7 +73,7 @@ Steps
                   common user, append ``CONTAINER=ALL`` to each permission, for
                   example:
 
-                  .. code-block:: Sql
+                  .. code-block:: sql
                      :copyable: false
                   
                      GRANT SET CONTAINER TO c##common_user CONTAINER=ALL;

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -100,38 +100,43 @@ Steps
                   GRANT SELECT ON V$ARCHIVED_LOG TO <user>;
                   GRANT SELECT ON V$ARCHIVE_DEST_STATUS TO <user>;
                   GRANT SELECT ON V$TRANSACTION TO <user>;
+                  GRANT SELECT ON V_$MYSTAT TO <user>;
+                  GRANT SELECT ON V_$STATNAME TO <user>; 
 
-         .. step:: Turn on ``LogMiner`` at the database level
+         .. step:: Turn on archive logging
             
-            To run continous jobs against Oracle, you must enable 
-            ``LogMiner`` at the database level. The following code-block
-            is an example of automatically-generated code, which you 
-            can run manually by substituting your database name:
+            a. To check if archive logging is already enabled, run the following query:
 
-            .. code-block:: sql
-                :copyable: true
+               .. code-block:: sql
+                  :copyable: true
 
-                ALTER SYSTEM SET db_recovery_file_dest_size = 10G;
-                ALTER SYSTEM SET db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' SCOPE=spfile;
-                SHUTDOWN IMMEDIATE;
-                STARTUP MOUNT
-                ALTER DATABASE ARCHIVELOG;
-                ALTER DATABASE OPEN;
+                  SELECT LOG_MODE FROM V$DATABASE;
+
+               This outputs ``ARCHIVELOG`` if logging is enabled, or
+               ``NOARCHIVELOG`` if it isn't.
             
-            .. tip::
+            #. Enable archive logging if it isn't already enabled.
+            
+               The following is an example of the code Relational Migrator
+               generates for enabling logging, which you can run manually by
+               substituting your database name. If you're migrating a
+               multi-tenant database, run these commands on the
+               container/master database.
 
-                To check if ``LogMiner`` is already enabled, run the 
-                following query:
+               .. code-block:: sql
+                  :copyable: true
 
-                .. code-block:: sql
-                   :copyable: true
-
-                    SELECT LOG_MODE FROM V$DATABASE; 
+                  ALTER SYSTEM SET db_recovery_file_dest_size = 10G;
+                  ALTER SYSTEM SET db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' scope=spfile;
+                  SHUTDOWN IMMEDIATE;
+                  STARTUP MOUNT
+                  ALTER DATABASE ARCHIVELOG;
+                  ALTER DATABASE OPEN;
     
          .. step:: Enable supplemental logging
 
-            a. To run continuous migration jobs against Oracle, you must 
-               enable supplemental logging at the database level:
+            a. To run continuous migration jobs against Oracle, enable 
+               supplemental logging:
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -123,7 +123,7 @@ Steps
     
          .. step:: Enable supplemental logging
 
-            a. Enable supplemental logging:
+            a. Enable supplemental logging on the database:
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -10,12 +10,12 @@ Configure Migration Prerequisites for Oracle
    :depth: 1
    :class: singlecol
 
-To run migration jobs from an Oracle source database, the database may require 
-some configuration changes. If Relational Migrator determines the 
+When migrating data from an Oracle source database, the database may require 
+configuration changes. If Relational Migrator determines the 
 database needs configuration changes, it automatically generates a 
-SQL script with the required changes. It is recommended to have a 
-Database Administrator (DBA) review the commands in this script and 
-perform their execution on the database server. The 
+SQL script with the required changes. Have a Database Administrator (DBA)
+review the script and run the commands on the database server. 
+
 Oracle configurations depend on the type of migration job:
 
 .. include:: /includes/fact-short-sync-job-desc.rst
@@ -28,12 +28,15 @@ About this Task
 
 - If you're migrating from an Oracle 12c instance, you must run commands as 
   the SYSDBA role.
-- In Oracle 12c the concept of a pluggable database was introduced. Some
-  of these commands can be run on PDB(plugable database) while commands 
+- Oracle 12c introduced the concept of a pluggable database. Some
+  of these commands can be run on a PDB (pluggable database), while commands 
   such as enabling ``ARCHIVELOG`` must be run on the
-  CDB(container/master database). For details on each architecture, 
+  CDB (container/master database). For details on each architecture, 
   see `Overview of Container Databases and Pluggable Databases
   <https://oracle-base.com/articles/12c/multitenant-overview-container-database-cdb-12cr1>`__.
+- Some commands differ based on whether the database is single or
+  multi-tenant. In a multi-tenant database, permissions must
+  include the suffix ``CONTAINER=ALL``
 - Supplemental logging is not allowed in Oracle Express editions.
 
 Steps
@@ -62,7 +65,18 @@ Steps
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
             c. Grant additional permissions to the service account 
-               to run continuous migration jobs:
+               to run continuous migration jobs. 
+               
+               .. important::
+               
+                  If you're migrating a multi-tenant container database as a
+                  common user, append ``CONTAINER=ALL`` to each permission, for
+                  example:
+
+                  .. code-block:: Sql
+                     :copyable: false
+                  
+                     GRANT SET CONTAINER TO c##common_user CONTAINER=ALL;
 
                .. code-block:: sql
                   :copyable: true

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -10,11 +10,11 @@ Configure Migration Prerequisites for Oracle
    :depth: 1
    :class: singlecol
 
-When migrating data from an Oracle source database, the database may require 
+When you migrate data from an Oracle source database, that database may require 
 configuration changes. If Relational Migrator determines the 
 database needs configuration changes, it automatically generates a 
 SQL script with the required changes. Have a Database Administrator (DBA)
-review the script, then have them run the commands on the database server. 
+review the script and run the commands on the database server. 
 
 Oracle configuration depends on the type of migration job:
 
@@ -28,15 +28,15 @@ About this Task
 
 - If you're migrating from an Oracle 12c instance, you must run commands as 
   the SYSDBA role.
-- Oracle 12c introduced the concept of a pluggable database. Some
+- Oracle 12c introduced the concept of a pluggable database (PDB). Some
   of these commands can be run on a PDB (pluggable database), while commands 
-  such as enabling ``ARCHIVELOG`` must be run on the
-  CDB (container/master database). For details on each architecture, 
+  like enabling ``ARCHIVELOG`` must be run on the
+  container/master database (CDB). For details on each architecture, 
   see `Overview of Container Databases and Pluggable Databases
   <https://oracle-base.com/articles/12c/multitenant-overview-container-database-cdb-12cr1>`__.
 - Some commands differ based on whether the database is single or
   multi-tenant. In a multi-tenant database, permissions must
-  include the suffix ``CONTAINER=ALL``
+  include the suffix ``CONTAINER=ALL``.
 - Oracle Express editions don't support logging the necessary information for
   continuous migration jobs, so you can't run continuous migration against an
   Oracle XE database.
@@ -98,7 +98,7 @@ Steps
 
          .. step:: Turn on archive logging
             
-            a. To check if archive logging is already enabled, run the following query:
+            a. To see if archive logging is already enabled, run the following query:
 
                .. code-block:: sql
                   :copyable: true
@@ -108,10 +108,10 @@ Steps
                This outputs ``ARCHIVELOG`` if logging is enabled, or
                ``NOARCHIVELOG`` if it isn't.
             
-            #. Enable archive logging if it isn't already enabled.
+            #. If archive logging isn't already enabled,  enable it. 
             
                The following is an example of the code Relational Migrator
-               generates for enabling logging, which you can run manually by
+               The following code is an example. You can run it manually if you
                substituting your database name. If you're migrating a
                multi-tenant database, run these commands on the
                container/master database.
@@ -128,7 +128,7 @@ Steps
     
          .. step:: Enable supplemental logging
 
-            a. To run continuous migration jobs against Oracle, enable 
+            a. Enable 
                supplemental logging:
 
                .. code-block:: sql

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -37,7 +37,9 @@ About this Task
 - Some commands differ based on whether the database is single or
   multi-tenant. In a multi-tenant database, permissions must
   include the suffix ``CONTAINER=ALL``
-- Supplemental logging is not allowed in Oracle Express editions.
+- Oracle Express editions don't support logging the necessary information for
+  continuous migration jobs, so you can't run continuous migration against an
+  Oracle XE database.
 
 Steps
 -----

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -67,8 +67,9 @@ Steps
             .. include:: /includes/fact-data-prep-oracle-step1.rst
 
             d. Grant additional permissions to the service account 
-               to run continuous migration jobs, appending ``CONTAINER=ALL`` if
-               migrating a multi-tenant container database:
+               to run continuous migration jobs. 
+               
+               Append ``CONTAINER=ALL`` if you're migrating a multi-tenant container database.
 
                .. code-block:: sql
                   :copyable: true


### PR DESCRIPTION
## DESCRIPTION
- Explicitly calls out Oracle XE as unsupported for continuous migration
- Clarifies differences between multi-tenant and single tenant config
- Clarifies that logging setup is for archive + supplemental logging

## STAGING
[Configure Migration Prerequisites for Oracle](https://deploy-preview-188--docs-relational-migrator.netlify.app/jobs/prerequisites/oracle/#configure-migration-prerequisites-for-oracle)

## JIRA
https://jira.mongodb.org/browse/DOCSP-45339

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)