### PR TITLE
DOCSP-46979 X509 authentication

### DIFF
--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -18,14 +18,13 @@ connections to your MongoDB database.
 Relational Migrator supports all connection string options except
 :urioption:`appName`. It overrides ``appName`` when connecting to your MongoDB
 deployment. For details on MongoDB connection string options, see 
-:manual:`Connection Strings <mongodb-uri>`.
+:manual:`Connection Strings </reference/connection-string>`.
 
-MongoDB User
-------------
+.. important::
 
-For both Atlas and on-premises deployments, create a separate
-:ref:`MongoDB user <rm-mongodb-service-user>` for Relational Migrator with
-:authrole:`readWrite` access to your MongoDB database.
+   For both Atlas and on-premises deployments, create a separate
+   :ref:`MongoDB user <rm-mongodb-service-user>` for Relational Migrator with
+   :authrole:`readWrite` access to your MongoDB database.
 
 Atlas Connection URI
 --------------------
@@ -54,3 +53,6 @@ For example, to use an account named ``migrator-service`` to connect to the
 .. code-block::
 
    mongodb://migrator-service:password@localhost:27017/MongoEnterprises
+
+X.509 Authentication
+--------------------

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -58,11 +58,13 @@ For example, to use an account named ``migrator-service`` with password
 Adding X.509 Authentication
 ---------------------------
 
-To connect to MongoDB using X.509 authentication, set the following options:
+To connect to MongoDB using X.509 authentication, omit a username and password.
+Instead, specify the on-premises host and port or the Atlas cluster URL and set 
+the following options:
 
 .. code-block::
 
-   <atlas or on-premises connection URI>?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
+   <on-premises host:port or clusterurl.mongodb.net>?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
 
 
 .. list-table::

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -102,9 +102,9 @@ the following options:
        key infrastructure. The path to the local ``.pem`` file that contains 
        the root certificate chain from the Certificate Authority.
 
-For example, to connect to the ``MongoEnterprises`` database using the
-certificate file ``/etc/ssl/caToValidateServerCertificates.p12``, with file 
-password ``verysecure``:
+For example, to connect to the ``MongoEnterprises`` database on 
+``cluster1.abc123.mongodb.net``, using the certificate file 
+``/etc/ssl/caToValidateServerCertificates.p12`` with the password ``verysecure``:
 
 .. code-block::
 

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -100,11 +100,10 @@ To connect to MongoDB using X.509 authentication, set the following options:
        key infrastructure. The path to the local ``.pem`` file that contains 
        the root certificate chain from the Certificate Authority.
 
-For example, to use an account named ``migrator-service`` with password
-``hunter2``to connect to the ``MongoEnterprises`` database, with the
-certificate file ``/etc/ssl/caToValidateServerCertificates.p12`` and file 
+For example, to connect to the ``MongoEnterprises`` database using the
+certificate file ``/etc/ssl/caToValidateServerCertificates.p12``, with file 
 password ``verysecure``:
 
 .. code-block::
 
-   mongodb+srv://migrator-service:hunter2@cluster1.abc123.mongodb.net/MongoEnterprises?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/etc/ssl/caToValidateServerCertificates.p12&tlsCertificateKeyFilePassword=verysecure
+   mongodb+srv://cluster1.abc123.mongodb.net/MongoEnterprises?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/etc/ssl/caToValidateServerCertificates.p12&tlsCertificateKeyFilePassword=verysecure

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -55,7 +55,7 @@ For example, to use an account named ``migrator-service`` with password
 
 .. _rm-x509-auth:
 
-Adding X.509 Authentication
+Using X.509 Authentication
 ---------------------------
 
 To connect to MongoDB using X.509 authentication, omit a username and password.

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -15,10 +15,9 @@ MongoDB Database Connection Strings
 This page describes the Uniform Resource Identifier (URI) formats for defining
 connections to your MongoDB database. 
 
-Relational Migrator supports all connection string options except
-:urioption:`appName`. It overrides ``appName`` when connecting to your MongoDB
-deployment. For details on MongoDB connection string options, see 
-:manual:`Connection Strings </reference/connection-string>`.
+Relational Migrator supports all :manual:`MongoDB connection string options
+</reference/connection-string-options/>` except :urioption:`appName`. It
+overrides ``appName`` when connecting to your MongoDB deployment.
 
 .. important::
 
@@ -33,12 +32,12 @@ Atlas Connection URI
 
    mongodb+srv://username:password@clusterurl.mongodb.net/database
 
-For example, to use an account named ``migrator-service`` to connect to the
-``MongoEnterprises`` database:
+For example, to use an account named ``migrator-service`` with password
+``hunter2`` to connect to the ``MongoEnterprises`` database:
 
 .. code-block::
 
-   mongodb+srv://migrator-service:password@sandbox.xxxxx.mongodb.net/MongoEnterprises
+   mongodb+srv://migrator-service:hunter2@cluster1.abc123.mongodb.net/MongoEnterprises
 
 On-Premises Connection URI
 --------------------------
@@ -47,12 +46,62 @@ On-Premises Connection URI
 
    mongodb://username:password@host:port/database
 
-For example, to use an account named ``migrator-service`` to connect to the
-``MongoEnterprises`` database:
+For example, to use an account named ``migrator-service`` with password
+``hunter2`` to connect to the ``MongoEnterprises`` database:
 
 .. code-block::
 
-   mongodb://migrator-service:password@localhost:27017/MongoEnterprises
+   mongodb://migrator-service:hunter2@localhost:27017/MongoEnterprises
+
+.. _rm-x509-auth:
 
 X.509 Authentication
 --------------------
+
+To connect to MongoDB using X.509 authentication, set the following
+:manual:`authentication </reference/connection-string-options/#authentication-options>`
+and :manual:`tls </reference/connection-string-options/#tls-options>` options:
+
+.. code-block::
+
+   mongodb+srv://clusterurl.mongodb.net/database?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Value
+
+   * - :urioption:`authSource`
+     - ``$external``
+
+   * - :urioption:`authMechanism`
+     - ``MONGODB-X509``
+
+   * - :urioption:`tlsCertificateKeyFile`
+     - The ``.p12`` file that contains Relational Migrator's certificate and 
+       key to present to the mongod or mongos instance.
+       
+       If your certificate is saved as a ``.pem`` file, you can
+       convert it using a tool like OpenSSL's `PKCS12 command <https://docs.openssl.org/master/man1/openssl-pkcs12/>`__:
+
+       .. code-block:: bash
+          :copyable: true
+
+          openssl pkcs12 -export -inkey cert_key_pem.txt -in cert_key.pem -out
+          cert_key.p12
+
+   * - :urioption:`tlsCertificateKeyFilePassword`
+     - The password to de-crypt the ``.p12`` file. 
+
+   * - :urioption:`tlsCAFile`
+     - Required only if the MongoDB instance has a TLS/SSL setup with its own public
+       key infrastructure. The path to the public root CA ``.pem`` file.
+
+For example, to connect to the ``MongoEnterprises`` database with the
+certificate file ``\foo.p12`` and file password ``verysecure``:
+
+.. code-block::
+
+   mongodb+srv://cluster1.abc123.mongodb.net/MongoEnterprises?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=verysecure

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -62,7 +62,7 @@ To connect to MongoDB using X.509 authentication, set the following options:
 
 .. code-block::
 
-   <base connection URI>?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
+   <atlas or on-premises connection URI>?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
 
 
 .. list-table::
@@ -100,9 +100,11 @@ To connect to MongoDB using X.509 authentication, set the following options:
        key infrastructure. The path to the local ``.pem`` file that contains 
        the root certificate chain from the Certificate Authority.
 
-For example, to connect to the ``MongoEnterprises`` database with the
-certificate file ``\foo.p12`` and file password ``verysecure``:
+For example, to use an account named ``migrator-service`` with password
+``hunter2``to connect to the ``MongoEnterprises`` database, with the
+certificate file ``/etc/ssl/caToValidateServerCertificates.p12`` and file 
+password ``verysecure``:
 
 .. code-block::
 
-   mongodb+srv://cluster1.abc123.mongodb.net/MongoEnterprises?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=verysecure
+   mongodb+srv://migrator-service:hunter2@cluster1.abc123.mongodb.net/MongoEnterprises?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/etc/ssl/caToValidateServerCertificates.p12&tlsCertificateKeyFilePassword=verysecure

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -55,16 +55,14 @@ For example, to use an account named ``migrator-service`` with password
 
 .. _rm-x509-auth:
 
-X.509 Authentication
---------------------
+Adding X.509 Authentication
+---------------------------
 
-To connect to MongoDB using X.509 authentication, set the following
-:manual:`authentication </reference/connection-string-options/#authentication-options>`
-and :manual:`tls </reference/connection-string-options/#tls-options>` options:
+To connect to MongoDB using X.509 authentication, set the following options:
 
 .. code-block::
 
-   mongodb+srv://clusterurl.mongodb.net/database?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
+   <base connection URI>?authSource=$external&authMechanism=MONGODB-X509&tlsCertificateKeyFile=/path/to/cert/client.p12&tlsCertificateKeyFilePassword=certpassword
 
 
 .. list-table::
@@ -80,11 +78,13 @@ and :manual:`tls </reference/connection-string-options/#tls-options>` options:
      - ``MONGODB-X509``
 
    * - :urioption:`tlsCertificateKeyFile`
-     - The ``.p12`` file that contains Relational Migrator's certificate and 
-       key to present to the mongod or mongos instance.
-       
-       If your certificate is saved as a ``.pem`` file, you can
-       convert it using a tool like OpenSSL's `PKCS12 command <https://docs.openssl.org/master/man1/openssl-pkcs12/>`__:
+     - The path to the ``.p12`` file that contains the certificate and key to 
+       present to the mongod or mongos instance.
+
+       :yellow:`IMPORTANT:` Unlike other MongoDB products, Relational Migrator
+       requires a path to a ``.p12`` file, not a ``.pem`` file. If your 
+       certificate is saved as a ``.pem`` file, you can convert it using a tool 
+       like OpenSSL's `PKCS12 command <https://docs.openssl.org/master/man1/openssl-pkcs12/>`__:
 
        .. code-block:: bash
           :copyable: true
@@ -97,7 +97,8 @@ and :manual:`tls </reference/connection-string-options/#tls-options>` options:
 
    * - :urioption:`tlsCAFile`
      - Required only if the MongoDB instance has a TLS/SSL setup with its own public
-       key infrastructure. The path to the public root CA ``.pem`` file.
+       key infrastructure. The path to the local ``.pem`` file that contains 
+       the root certificate chain from the Certificate Authority.
 
 For example, to connect to the ``MongoEnterprises`` database with the
 certificate file ``\foo.p12`` and file password ``verysecure``:

--- a/source/connection-strings/mongodb-database-connection-strings.txt
+++ b/source/connection-strings/mongodb-database-connection-strings.txt
@@ -83,7 +83,7 @@ the following options:
      - The path to the ``.p12`` file that contains the certificate and key to 
        present to the mongod or mongos instance.
 
-       :yellow:`IMPORTANT:` Unlike other MongoDB products, Relational Migrator
+       :gold:`IMPORTANT:` Unlike other MongoDB products, Relational Migrator
        requires a path to a ``.p12`` file, not a ``.pem`` file. If your 
        certificate is saved as a ``.pem`` file, you can convert it using a tool 
        like OpenSSL's `PKCS12 command <https://docs.openssl.org/master/man1/openssl-pkcs12/>`__:

--- a/source/database-connections/save-mongodb-connection.txt
+++ b/source/database-connections/save-mongodb-connection.txt
@@ -46,7 +46,7 @@ To save a new connection from the :guilabel:`Connections` page:
    .. step:: Enter the MongoDB connection string
 
       a. In :guilabel:`MongoDB connection string (URI)`, enter
-         your :manual:`MongoDB URI <mongodb-uri>`.
+         your :manual:`MongoDB URI </reference/connection-string>`.
 
       #. If it isn't included in the connection string, enter the
          :guilabel:`Database` to connect to.

--- a/source/database-connections/save-mongodb-connection.txt
+++ b/source/database-connections/save-mongodb-connection.txt
@@ -48,12 +48,16 @@ To save a new connection from the :guilabel:`Connections` page:
       a. In :guilabel:`MongoDB connection string (URI)`, enter
          your :manual:`MongoDB URI </reference/connection-string>`.
 
+         If you're using :ref:`X.509 authentication <rm-x509-auth>`, Relational
+         Migrator verifies the connection string syntax and the certificate file format.
+
       #. If it isn't included in the connection string, enter the
          :guilabel:`Database` to connect to.
       
-      #. If they aren't included in the connection string, enter the 
-         :guilabel:`Username` and :guilabel:`Password` of your
-         :ref:`Relational Migrator MongoDB user <rm-mongodb-service-user>`.
+      #. If they aren't included in the connection string and you aren't using
+         X.509 authentication, enter the :guilabel:`Username` and
+         :guilabel:`Password` of your :ref:`Relational Migrator MongoDB user
+         <rm-mongodb-service-user>`.
          
          Checking :guilabel:`Save password` saves the password securely
          on your machine, so you don't have to enter the :guilabel:`Username`

--- a/source/includes/steps-atlas-cluster.rst
+++ b/source/includes/steps-atlas-cluster.rst
@@ -4,7 +4,7 @@
 
 If you are using MongoDB Atlas, you can select your Atlas cluster 
 from the :guilabel:`Select a cluster` list, or you can enter the
-:manual:`connection string <mongodb-uri>`.
+:manual:`connection string </reference/connection-string>`.
 
 If you are using an on-premises deployment, you must use the MongoDB
 connection string.
@@ -39,7 +39,7 @@ connection string.
       :tabid: enter-mongodb-uri
 
       a. In the :guilabel:`MongoDB connection string (URI)` field, input
-         your :manual:`MongoDB URI <mongodb-uri>`.
+         your :manual:`MongoDB URI </reference/connection-string>`.
 
       #. If it isn't included in the connection string, enter the
          :guilabel:`Database` to connect to.

--- a/source/includes/steps-create-mongodb-connection-short.rst
+++ b/source/includes/steps-create-mongodb-connection-short.rst
@@ -5,12 +5,17 @@ a. Enter the MongoDB connection string.
    a. In :guilabel:`MongoDB connection string (URI)`, enter
       your :manual:`MongoDB URI </reference/connection-string>`.
 
+      If you're using :ref:`X.509 authentication <rm-x509-auth>`, Relational
+      Migrator verifies the connection string syntax and the certificate file 
+      format.
+
    #. If it isn't included in the connection string, enter the
       :guilabel:`Database` to connect to.
    
-   #. If they aren't included in the connection string, enter the 
-      :guilabel:`Username` and :guilabel:`Password` of your
-      :ref:`Relational Migrator MongoDB user <rm-mongodb-service-user>`.
+   #. If they aren't included in the connection string and you aren't using
+      X.509 authentication, enter the :guilabel:`Username` and
+      :guilabel:`Password` of your :ref:`Relational Migrator MongoDB user
+      <rm-mongodb-service-user>`.
 
 #. Enter a :guilabel:`Connection name` and optional :guilabel:`Environment tag`.
 

--- a/source/includes/steps-create-mongodb-connection-short.rst
+++ b/source/includes/steps-create-mongodb-connection-short.rst
@@ -3,7 +3,7 @@
 a. Enter the MongoDB connection string.
 
    a. In :guilabel:`MongoDB connection string (URI)`, enter
-      your :manual:`MongoDB URI <mongodb-uri>`.
+      your :manual:`MongoDB URI </reference/connection-string>`.
 
    #. If it isn't included in the connection string, enter the
       :guilabel:`Database` to connect to.


### PR DESCRIPTION
## DESCRIPTION

- Adds X.509 authentication info to the MongoDB Connection Strings topic
- Fixes some broken links to the core server docs

## STAGING
[MongoDB Connection Strings: Using X.509 Authentication](https://deploy-preview-206--docs-relational-migrator.netlify.app/connection-strings/mongodb-database-connection-strings/#using-x.509-authentication)
[Save a MongoDB Connection](https://deploy-preview-206--docs-relational-migrator.netlify.app/database-connections/save-mongodb-connection/#enter-the-mongodb-connection-string)

## JIRA
https://jira.mongodb.org/browse/DOCSP-46979

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)