### PR TITLE
DOCSP-47252 adds redirects for moved prereq pages

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -46,3 +46,11 @@ define: versions master
 # DOCSP-46666 repetitive paths
 [*]: ${prefix}/projects/projects/ -> ${base}/projects/
 [*]: ${prefix}/table-filters/table-filters/ -> ${base}/table-filters/
+
+# DOCSP-47252 redirect pre-requisites pages moved in PR#104
+[*]: ${prefix}/prerequisites/ -> ${base}/jobs/prerequisites/
+[*]: ${prefix}/prerequisites/my-sql/ -> ${base}/jobs/prerequisites/my-sql/
+[*]: ${prefix}/prerequisites/oracle/ -> ${base}/jobs/prerequisites/oracle/
+[*]: ${prefix}/prerequisites/postgres/ -> ${base}/jobs/prerequisites/postgres/
+[*]: ${prefix}/prerequisites/sql-server/ -> ${base}/jobs/prerequisites/sql-server/
+[*]: ${prefix}/prerequisites/sybase/ -> ${base}/jobs/prerequisites/sybase/


### PR DESCRIPTION
## DESCRIPTION
Adds redirects for pages moved in #104 

## STAGING
`mut-redirects config/redirects` output:

```
Redirect 301 /docs/relational-migrator/prerequisites/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/
Redirect 301 /docs/relational-migrator/prerequisites/my-sql/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/my-sql/
Redirect 301 /docs/relational-migrator/prerequisites/oracle/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/oracle/
Redirect 301 /docs/relational-migrator/prerequisites/postgres/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/postgres/
Redirect 301 /docs/relational-migrator/prerequisites/sql-server/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/sql-server/
Redirect 301 /docs/relational-migrator/prerequisites/sybase/ https://www.mongodb.com/docs/relational-migrator/jobs/prerequisites/sybase/
```

## JIRA
https://jira.mongodb.org/browse/DOCSP-47252

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)