### PR TITLE
DOCSP-47270-remove-deprecated-appx-link

### DIFF
--- a/source/code-generation/query-converter/convert-stored-procedures.txt
+++ b/source/code-generation/query-converter/convert-stored-procedures.txt
@@ -31,8 +31,7 @@ Before you Begin
   driver code that hosts the database logic. Part of your application 
   modernization journey is to choose the programming language and hosting 
   option that best serves your application needs. You can host your
-  converted stored procedure code in your application or with 
-  :ref:`MongoDB App Services Functions <functions>`.
+  converted stored procedure code in your application.
 
 - .. include:: /includes/fact-query-converter-disclaimer.rst
 

--- a/source/code-generation/query-converter/convert-stored-procedures.txt
+++ b/source/code-generation/query-converter/convert-stored-procedures.txt
@@ -29,9 +29,9 @@ Before you Begin
 - MongoDB does not have an official synonym object type for the SQL 
   stored procedure. Instead, MongoDB supports custom JavaScript and 
   driver code that hosts the database logic. Part of your application 
-  modernization journey is to choose the programming language and hosting 
-  option that best serves your application needs. You can host your
-  converted stored procedure code in your application.
+  modernization journey is to choose the programming language that 
+  best serves your application needs. You can host your converted 
+  stored procedure code in your application.
 
 - .. include:: /includes/fact-query-converter-disclaimer.rst
 


### PR DESCRIPTION
## DESCRIPTION
Remove deprecated link to app services on this page: https://www.mongodb.com/docs/relational-migrator/code-generation/query-converter/convert-stored-procedures/

## STAGING
https://deploy-preview-213--docs-relational-migrator.netlify.app/code-generation/query-converter/convert-stored-procedures/#before-you-begin

## JIRA
https://jira.mongodb.org/browse/DOCSP-47270

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)