### PR TITLE
DOCSP-48310 Fixes typos in oracle db configuration script

### DIFF
--- a/source/includes/fact-data-prep-oracle-step1.rst
+++ b/source/includes/fact-data-prep-oracle-step1.rst
@@ -48,7 +48,7 @@ a. Create a service account:
       :copyable: true
 
       GRANT CREATE SESSION TO <user>;
-      GRANT SELECT ON V$DATABASE TO <user>;
+      GRANT SELECT ON V_$DATABASE TO <user>;
 
    If the service account *is not* the table owner:
 
@@ -58,5 +58,5 @@ a. Create a service account:
       GRANT CREATE SESSION TO <user>;
       GRANT SELECT_CATALOG_ROLE TO <user>;
       GRANT SELECT ANY TABLE TO <user>;
-      GRANT SELECT ON V$DATABASE TO <user>;
+      GRANT SELECT ON V_$DATABASE TO <user>;
       GRANT FLASHBACK ANY TABLE TO <user>;

--- a/source/jobs/prerequisites/oracle.txt
+++ b/source/jobs/prerequisites/oracle.txt
@@ -80,15 +80,15 @@ Steps
                   GRANT SELECT ON DBA_TABLESPACES TO <user>; 
                   GRANT EXECUTE ON DBMS_LOGMNR TO <user>;
                   GRANT EXECUTE ON DBMS_LOGMNR_D TO <user>;
-                  GRANT SELECT ON V$LOG TO <user>;
-                  GRANT SELECT ON V$LOG_HISTORY TO <user>;
-                  GRANT SELECT ON V$LOGMNR_LOGS TO <user>;
-                  GRANT SELECT ON V$LOGMNR_CONTENTS TO <user>;
-                  GRANT SELECT ON V$LOGMNR_PARAMETERS TO <user>;
-                  GRANT SELECT ON V$LOGFILE TO <user>;
-                  GRANT SELECT ON V$ARCHIVED_LOG TO <user>;
-                  GRANT SELECT ON V$ARCHIVE_DEST_STATUS TO <user>;
-                  GRANT SELECT ON V$TRANSACTION TO <user>;
+                  GRANT SELECT ON V_$LOG TO <user>;
+                  GRANT SELECT ON V_$LOG_HISTORY TO <user>;
+                  GRANT SELECT ON V_$LOGMNR_LOGS TO <user>;
+                  GRANT SELECT ON V_$LOGMNR_CONTENTS TO <user>;
+                  GRANT SELECT ON V_$LOGMNR_PARAMETERS TO <user>;
+                  GRANT SELECT ON V_$LOGFILE TO <user>;
+                  GRANT SELECT ON V_$ARCHIVED_LOG TO <user>;
+                  GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO <user>;
+                  GRANT SELECT ON V_$TRANSACTION TO <user>;
                   GRANT SELECT ON V_$MYSTAT TO <user>;
                   GRANT SELECT ON V_$STATNAME TO <user>; 
 


### PR DESCRIPTION
## DESCRIPTION
Updates the Oracle db configuration script to fix typos.

All `V$...` instances should be `V_$...` in step 1 parts C and D

## STAGING
https://deploy-preview-220--docs-relational-migrator.netlify.app/jobs/prerequisites/oracle/#set-up-user-permissions-1

## JIRA
https://jira.mongodb.org/browse/DOCSP-48310

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)