### PR TITLE
DOCSP-48536 Relational Migrator 1.13 release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -31,13 +31,14 @@ New features:
   - PostgreSQL
   - MySQL
 
-- Added support for keys in calculated fields when projects use a non-default
-  key handling option, such as inherited primary key.
-
 Bug fixes:
 
-- Fixed an issue where job API calls hang when table filters return an empty 
-  result.
+- Fixed an issue where job API calls would hang when table filters returned an
+  empty result.
+- Fixed an issue that prevented users from saving calculated key fields for 
+  projects that use the single-inherited or wrapped key handling options.
+- Fixed an issue with embedded array mappings and excluded fields, where blank 
+  source data could trigger an 'unset' error rather than being processed silently.
 
 
 1.12.0 Changelog

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -11,12 +11,39 @@ Release Notes
    :class: twocols
 
 Download the latest Relational Migrator binary from the `release page <https://www.mongodb.com/try/download/relational-migrator>`__. 
-For installation instructions, see the :ref:`Installation <installation>` page. 
+For installation instructions, see the :ref:`Installation <installation>` 
+page. 
+
+1.13.0 Changelog
+----------------
+
+*Released March 24, 2025*
+
+New features:
+
+- :ref:`Pre-Migration Analysis <rm-app-analysis>` is now in Public Preview. 
+  This feature allows you to identify migration issues before starting and get
+  actionable recommendations for a smooth migration. Pre Migration Analysis
+  supports the following databases:
+  
+  - Oracle
+  - SQL Server
+  - PostgreSQL
+  - MySQL
+
+- Added support for keys in calculated fields when projects use a non-default
+  key handling option, such as inherited primary key.
+
+Bug fixes:
+
+- Fixed an issue where job API calls hang when table filters return an empty 
+  result.
+
 
 1.12.0 Changelog
 ----------------
 
-*Released Febuary 3, 2025*
+*Released February 3, 2025*
 
 New features:
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -237,7 +237,7 @@ New features:
 
 - Users can :ref:`migrate time series data <rm-timeseries>` into MongoDB
   with native Time Series support.
-- Users can migrate data from TimescaleDB Hybertables.
+- Users can migrate data from TimescaleDB Hypertables.
 - Users can migrate from a database that has a name
   different from the name used when creating the corresponding project.
 - Migration performance improves by setting write concern to 1 by
@@ -304,7 +304,7 @@ Bug fixes:
 Improvements:
 
 - Improved synthetic foreign keys to be preserved after schema refresh.
-- Fix for fully-offline deployments in airgapped environments. 
+- Fix for fully-offline deployments in air gapped environments. 
 - Fix for certain combinations of mappings, specifically two different
   mappings at the same level of embedding. 
 - Various minor fixes and improvements to Sybase database support, CDC


### PR DESCRIPTION
## DESCRIPTION
- Adds release notes for RM 1.13, scheduled for release 3/24. Merge and publish on 3/21.
- Fixed a couple of old typos.

## STAGING
[1.13.0 Changelog](https://deploy-preview-234--docs-relational-migrator.netlify.app/release-notes/#1.13.0-changelog)

## JIRA
https://jira.mongodb.org/browse/DOCSP-48536

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?
The ref to the main Pre-Migration Analysis page links to a topic that will be merged in https://github.com/mongodb/docs-relational-migrator/pull/224

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)