### PR TITLE
DOCSP-48658 fixes rendering issue in create project w live DB

### DIFF
--- a/source/includes/project-initial-mappings.rst
+++ b/source/includes/project-initial-mappings.rst
@@ -1,5 +1,3 @@
-Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
-
 - :guilabel:`Start with a MongoDB schema that matches your relational schema`
    Creates your initial project with a new document mapping rule for each table.
 

--- a/source/includes/project-initial-mappings.rst
+++ b/source/includes/project-initial-mappings.rst
@@ -1,3 +1,5 @@
+Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+
 - :guilabel:`Start with a MongoDB schema that matches your relational schema`
    Creates your initial project with a new document mapping rule for each table.
 

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -46,54 +46,52 @@ Steps
       To create a new connection, click :guilabel:`Add a new connection`:
 
       .. include:: /includes/steps-create-relational-connection-short.rst
-
-.. step:: From the :guilabel:`Select tables` screen, indicate the tables you want to migrate and click :guilabel:`Next`.
-
-   The following table explains the different ways you can select tables to migrate: 
-
-   .. list-table::
-      :header-rows: 1
-      :widths: 25 75
-
-      * - Target
-        - Action
-
-      * - All tables within a database
-        - Click the check mark for the target database.
-
-      * -  All tables within a schema
-        - Expand the target database and click the check mark for the target schema.
-
-      * - Specific tables within a schema
-        - Expand the target database and schema. Select the target tables individually.
-    
-      * - Specific table names
-        - Use the :guilabel:`Filter` bar above the :guilabel:`Relational Schema` list.
-
-.. step:: Choose a :guilabel:`Global casing` option for collection names. 
    
-   This option affects the names of your collections created from the tables in your relational database:
-
-   - :guilabel:`Keep Original`: Keep the original casing used in your
-     relational database table name.
-
-   - :guilabel:`Override with Global Casing`: Override the original table name
-     with a global casing convention.
-
-     - ``TitleCase``
-     - ``camelCase``
-     - ``kebab-case``
-     - ``snake_case``
-     - ``UPPER_SNAKE_CASE``
-
-.. step:: Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+   .. step:: From the :guilabel:`Select tables` screen, indicate the tables you want to migrate and click :guilabel:`Next`.
    
-   .. include:: /includes/project-initial-mappings.rst
-
-.. step:: Enter a name for your project.
-
-.. step:: Click :guilabel:`Done`.
-
+      The following table explains the different ways you can select tables to migrate: 
+   
+      .. list-table::
+         :header-rows: 1
+         :widths: 25 75
+   
+         * - Target
+           - Action
+   
+         * - All tables within a database
+           - Click the check mark for the target database.
+   
+         * -  All tables within a schema
+           - Expand the target database and click the check mark for the target schema.
+   
+         * - Specific tables within a schema
+           - Expand the target database and schema. Select the target tables individually.
+       
+         * - Specific table names
+           - Use the :guilabel:`Filter` bar above the :guilabel:`Relational Schema` list.
+   
+   .. step:: Choose a :guilabel:`Global casing` option for collection names. 
+      
+      This option affects the names of your collections created from the tables in your relational database:
+   
+      - :guilabel:`Keep Original`: Keep the original casing used in your
+        relational database table name.
+   
+      - :guilabel:`Override with Global Casing`: Override the original table name
+        with a global casing convention.
+   
+        - ``TitleCase``
+        - ``camelCase``
+        - ``kebab-case``
+        - ``snake_case``
+        - ``UPPER_SNAKE_CASE``
+   
+   .. step:: .. include:: /includes/project-initial-mappings.rst
+   
+   .. step:: Enter a name for your project.
+   
+   .. step:: Click :guilabel:`Done`.
+   
 Next Steps
 ----------
 

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -86,7 +86,9 @@ Steps
         - ``snake_case``
         - ``UPPER_SNAKE_CASE``
    
-   .. step:: .. include:: /includes/project-initial-mappings.rst
+   .. step:: Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+      
+      .. include:: /includes/project-initial-mappings.rst
    
    .. step:: Enter a name for your project.
    

--- a/source/projects/create-project-live-connection.txt
+++ b/source/projects/create-project-live-connection.txt
@@ -86,7 +86,9 @@ Steps
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-.. step:: .. include:: /includes/project-initial-mappings.rst
+.. step:: Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+   
+   .. include:: /includes/project-initial-mappings.rst
 
 .. step:: Enter a name for your project.
 

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -172,7 +172,9 @@ Steps
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. .. include:: /includes/project-initial-mappings.rst
+#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+
+   .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -172,9 +172,7 @@ Steps
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema. 
-
-   .. include:: /includes/project-initial-mappings.rst
+#. .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 

--- a/source/projects/create-project-loading-schema-files.txt
+++ b/source/projects/create-project-loading-schema-files.txt
@@ -172,7 +172,9 @@ Steps
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. .. include:: /includes/project-initial-mappings.rst
+#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema. 
+
+   .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 

--- a/source/projects/create-project-sample-schema.txt
+++ b/source/projects/create-project-sample-schema.txt
@@ -119,7 +119,9 @@ skip step one.
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. .. include:: /includes/project-initial-mappings.rst
+#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+
+   .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 

--- a/source/projects/create-project-sample-schema.txt
+++ b/source/projects/create-project-sample-schema.txt
@@ -119,9 +119,7 @@ skip step one.
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
-   
-   .. include:: /includes/project-initial-mappings.rst
+#. .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 

--- a/source/projects/create-project-sample-schema.txt
+++ b/source/projects/create-project-sample-schema.txt
@@ -119,7 +119,9 @@ skip step one.
      - ``snake_case``
      - ``UPPER_SNAKE_CASE``
 
-#. .. include:: /includes/project-initial-mappings.rst
+#. Choose an :guilabel:`Initial mappings` option for your MongoDB schema.
+   
+   .. include:: /includes/project-initial-mappings.rst
 
 #. Enter a name for your project.
 


### PR DESCRIPTION
## DESCRIPTION
Fixes issue where final steps of create project w/live DB were not rendered

## STAGING

Bug Fix:
- https://deploy-preview-242--docs-relational-migrator.netlify.app/projects/create-project-live-connection/#from-the-select-tables-screen--indicate-the-tables-you-want-to-migrate-and-click-next.
  - Steps 3 -> end now show up
  - Step 5 now renders the include properly

No visible changes:
- These pages used the `include` file that was modified and were updated to accommodate the change.
  - https://deploy-preview-242--docs-relational-migrator.netlify.app/projects/create-project-loading-schema-files/#steps
    - Step 7 
  - https://deploy-preview-242--docs-relational-migrator.netlify.app/projects/create-project-sample-schema/#steps
    - Step 6





## JIRA
https://jira.mongodb.org/browse/DOCSP-48658

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)