### PR TITLE
DOCSP-48729-Update-Kafka-via-Docker-docs

### DIFF
--- a/source/installation/kafka-deployments/install-docker.txt
+++ b/source/installation/kafka-deployments/install-docker.txt
@@ -52,9 +52,9 @@ Steps
 
    .. step:: Configure environment variables
 
-      a. Configure ``MIGRATOR_DATA_PATH``
+      a. Configure ``MIGRATOR_PATH_DATA``
 
-         In your ``docker-compose`` file, configure the ``MIGRATOR_DATA_PATH`` variable to a 
+         In your ``docker-compose`` file, configure the ``MIGRATOR_PATH_DATA`` variable to a 
          path where Relational Migrator saves data for persistence.
 
       b. (Optional) If your source database is MySQL or Oracle, configure ``MIGRATOR_PATH_DRIVER``


### PR DESCRIPTION
## DESCRIPTION
Incorrect environmental variable. Instead of `MIGRATOR_DATA_PATH` it should be `MIGRATOR_PATH_DATA`.

## STAGING

[Configure Environmental Variables](https://deploy-preview-244--docs-relational-migrator.netlify.app/installation/kafka-deployments/install-docker/#configure-environment-variables)

## JIRA
https://jira.mongodb.org/browse/DOCSP-48729

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)