### PR TITLE
DOCSP-49304 fixes bad redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -66,7 +66,7 @@ define: versions master
 [*]: ${prefix}/mapping-rules/new-rules-from-relational -> ${base}/mapping-rules/create-rules
 [*]: ${prefix}/mapping-rules/new-rules-to-mongodb -> ${base}/mapping-rules/create-rules
 ## jobs
-[*]: ${prefix}/jobs/prerequisites -> ${base}/database-connections/database-connections
+[*]: ${prefix}/jobs/prerequisites -> ${base}/database-connections
 ## installation
 [*]: ${prefix}/installation/deployment-considerations -> ${base}/installation
 [*]: ${prefix}/installation/install-on-an-unattended-server/debian-server-installation/debian-system-service -> ${base}/installation/install-on-an-unattended-server/debian-server-installation
@@ -80,12 +80,12 @@ define: versions master
 [*]: ${prefix}/getting-started/migration-scenarios -> ${base}/getting-started
 [*]: ${prefix}/getting-started/supported-databases -> ${base}/getting-started
 ## database connections
-[*]: ${prefix}/database-connections/save-mongodb-connection -> ${base}/database-connections/database-connections
-[*]: ${prefix}/database-connections/save-relational-connection -> ${base}/database-connections/database-connections
+[*]: ${prefix}/database-connections/save-mongodb-connection -> ${base}/database-connections
+[*]: ${prefix}/database-connections/save-relational-connection -> ${base}/database-connections
 ## connection strings
-[*]: ${prefix}/connection-strings -> ${base}/database-connections/database-connections
-[*]: ${prefix}/connection-strings/mongodb-database-connection-strings -> ${base}/database-connections/database-connections
-[*]: ${prefix}/connection-strings/relational-database-connection-strings -> ${base}/database-connections/database-connections
+[*]: ${prefix}/connection-strings -> ${base}/database-connections
+[*]: ${prefix}/connection-strings/mongodb-database-connection-strings -> ${base}/database-connections
+[*]: ${prefix}/connection-strings/relational-database-connection-strings -> ${base}/database-connections
 
 # DOCSP-48961 final review before merging docs-uplift into master
 [*]: ${prefix}/projects/create-project-sample-schema -> ${base}/database-connections/create-project-sample-schema


### PR DESCRIPTION
## DESCRIPTION
Fixes bad redirects

Originally I redirected to `/database-connections/database-connections`.
This page was moved to `/database-connections` while the uplift project was in progress

## STAGING
N/A

## JIRA
https://jira.mongodb.org/browse/DOCSP-49304


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)