### PR TITLE
DOCSP-29877-data-cleaned-up-when-continuous-job-is-complete

### DIFF
--- a/source/includes/fact-cdc-cleanup.rst
+++ b/source/includes/fact-cdc-cleanup.rst
@@ -1,0 +1,2 @@
+Continuous migration jobs may create additional cache collections that are 
+removed upon completion.

--- a/source/jobs/creating-jobs.txt
+++ b/source/jobs/creating-jobs.txt
@@ -29,6 +29,8 @@ About this Task
 
 - .. include:: /includes/fact-cdc-recoverable.rst
 
+- .. include:: /includes/fact-cdc-cleanup.rst
+
 Before you Begin
 ----------------
 
@@ -155,4 +157,3 @@ each database, see the following:
 * `Oracle <https://debezium.io/documentation/reference/stable/connectors/oracle.html#_preparing_the_database>`__
 * `PostgreSQL <https://debezium.io/documentation/reference/stable/connectors/postgresql.html#setting-up-postgresql>`__
 * `SQL Server <https://debezium.io/documentation/reference/stable/connectors/sqlserver.html#setting-up-sqlserver>`__
-


### PR DESCRIPTION
## DESCRIPTION
Adding a bullet point to _About This Task_ to state that continuous migration jobs may create temporary collections (cache collections) that will be removed upon completion. 

## STAGING

- [Create a Migration Job - About This Task](url)

## JIRA
https://jira.mongodb.org/browse/DOCSP-29877

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)