### PR TITLE
DOCSP-30122-clarify-initial-schema-mappings-options

### DIFF
--- a/source/includes/project-initial-mappings.rst
+++ b/source/includes/project-initial-mappings.rst
@@ -1,5 +1,12 @@
 - :guilabel:`Start with a MongoDB schema that matches your relational schema`
-   Creates your initial project with a new document mapping rule for each table.
+   Creates your initial project with a new document mapping rule for each table. 
+   This option displays a table of imported relational tables, which are grouped 
+   by database and schema, and listed in alphabetical order. Each collection 
+   is represented as a :guilabel:`top-level` collection. You can view the 
+   corresponding collection name in each table. For collection names, 
+   {+rel-mig+} applies global casing to the original table name.
+
+
 
 - :guilabel:`Start with a recommended MongoDB schema`
    {+rel-mig+} creates mapping rules for a suggested MongoDB schema. 


### PR DESCRIPTION
## DESCRIPTION
After reviewing this ticket, it appears we cover the workflow for `Start with a recommended MongoDB schema` pretty well [in the doc](https://www.mongodb.com/docs/relational-migrator/database-connections/create-project-loading-schema-files/#steps:~:text=Choose%20an%20Initial%20mappings%20option%20for%20your%20MongoDB%20schema.). We definitely do not provide this level of detail for the `Start with a MongoDB schema that matches your relational schema` option, which I think could be confusing when users are trying to differentiate the options before trying them out.

I added some additional details to the matching option to bring it up to the level of detail as the recommended schema option.

## STAGING


## JIRA
https://jira.mongodb.org/browse/DOCSP-30122

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)