### PR TITLE
DOP-5496: Create GH action to deploy Bump pages

### DIFF
--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -5,14 +5,14 @@ on:
   workflow_dispatch: # Allow manual trigger in case of quick fix
   push:
     branches:
-      - main
+      - master
     paths:
       - 'source/rm-openapi-latest.json'
 
   # For previews
   pull_request:
     branches:
-      - main
+      - master
     paths:
       - 'source/rm-openapi-latest.json'
 

--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -1,0 +1,52 @@
+name: Check & deploy API documentation
+
+on:
+  # For deployments
+  workflow_dispatch: # Allow manual trigger in case of quick fix
+  push:
+    branches:
+      - main
+    paths:
+      - 'source/rm-openapi-latest.json'
+
+  # For previews
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'source/rm-openapi-latest.json'
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-doc:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    name: Deploy API documentation on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.RM_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/rm-openapi-latest.json
+          branch: main
+  
+  api-preview:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Create API preview on Bump.sh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create API preview
+        uses: bump-sh/github-action@59eaae922e81ac8d127bd2b2ac6dc4804bda8a4c
+        with:
+          doc: ${{vars.RM_DOC_ID}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: source/rm-openapi-latest.json
+          branch: main
+          command: preview

--- a/source/rm-openapi-latest.json
+++ b/source/rm-openapi-latest.json
@@ -17,7 +17,7 @@
     "/analysis/{projectId}/task": {
       "get": {
         "operationId": "getAnalysisTask",
-        "description": "Get pre-migration analysis task by `projectId`!",
+        "description": "Get pre-migration analysis task by `projectId`.",
         "parameters": [
           {
             "name": "projectId",

--- a/source/rm-openapi-latest.json
+++ b/source/rm-openapi-latest.json
@@ -17,7 +17,7 @@
     "/analysis/{projectId}/task": {
       "get": {
         "operationId": "getAnalysisTask",
-        "description": "Get pre-migration analysis task by `projectId`.",
+        "description": "Get pre-migration analysis task by `projectId`!",
         "parameters": [
           {
             "name": "projectId",


### PR DESCRIPTION
## DESCRIPTION

This PR introduces a GitHub integration for Bump.sh, the new OpenAPI spec renderer that we'll be using in place of our fork of Redoc. The goal of this is to have a simple integration that we can use to start publishing the Relational Migrator OpenAPI spec to Bump.

The workflow allows users to use Bump to create a preview when changes to the OpenAPI spec is found. When the change is merged to the `master` branch, it'll allow Bump to automatically publish the latest OpenAPI spec to prod.

Bump prints out a link to previews in the GH action ([example](https://github.com/mongodb/docs-relational-migrator/actions/runs/15122415555/job/42507608499#step:3:12)).

This should be similar to the workflow introduced for the Atlas Admin API ([see file](https://github.com/mongodb/openapi/blob/a2b063882d0c5afda5f10aacdfbc6dbb111eb5e5/.github/workflows/generate-bump-pages.yml)).

## JIRA

[DOP-5496](https://jira.mongodb.org/browse/DOP-5496)

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)